### PR TITLE
Use built-in tomllib and improve output formatting

### DIFF
--- a/deploy_cowrie_honeypot.sh
+++ b/deploy_cowrie_honeypot.sh
@@ -145,14 +145,16 @@ sshd -t > /dev/null
 systemctl restart sshd > /dev/null
 EOF
 
-echo -n "[*] SSH moved to port $REAL_SSH_PORT. Reconnecting."
+echo "[*] SSH moved to port $REAL_SSH_PORT. Reconnecting..."
 sleep 3
 
 # Test new SSH port
+echo -n "[*] Testing SSH on port $REAL_SSH_PORT"
 until ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -o ConnectTimeout=3 -p "$REAL_SSH_PORT" "root@$SERVER_IP" "echo -n ." 2>/dev/null; do
     printf "."
     sleep 2
 done
+echo ""
 echo "[*] SSH confirmed on port $REAL_SSH_PORT."
 
 # ============================================================
@@ -570,9 +572,9 @@ if [ "$ENABLE_REPORTING" = "true" ] && [ -f "$MASTER_CONFIG" ]; then
     # Process master config to generate server config
     echo "[*] Processing master-config.toml..."
     if command -v uv &> /dev/null; then
-        uv run scripts/process-config.py "$MASTER_CONFIG" > /tmp/server-report.env
+        uv run --quiet scripts/process-config.py "$MASTER_CONFIG" > /tmp/server-report.env 2>&1
     elif command -v python3 &> /dev/null; then
-        python3 scripts/process-config.py "$MASTER_CONFIG" > /tmp/server-report.env
+        python3 scripts/process-config.py "$MASTER_CONFIG" > /tmp/server-report.env 2>&1
     else
         echo "[!] Error: Neither uv nor python3 found. Cannot process config."
         echo "[!] Skipping automated reporting setup."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 readme = "README.md"
 license = { text = "MIT" }
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 
 dependencies = [
     # HTTP requests (VirusTotal, webhooks, SendGrid/Mailgun)
@@ -18,9 +18,6 @@ dependencies = [
 
     # YARA malware scanning
     "yara-python>=4.3.1",
-
-    # TOML config parsing
-    "tomli>=2.0.1; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/scripts/process-config.py
+++ b/scripts/process-config.py
@@ -9,13 +9,8 @@ Reads master-config.toml, executes any shell commands in values
 import sys
 import subprocess
 import re
+import tomllib
 from pathlib import Path
-
-try:
-    import tomli
-except ImportError:
-    print("Error: tomli not installed. Install with: uv add tomli", file=sys.stderr)
-    sys.exit(1)
 
 
 def execute_command(value: str) -> str:
@@ -66,7 +61,7 @@ def execute_command(value: str) -> str:
 def process_config(config_path: str) -> dict:
     """Process config file and execute any commands."""
     with open(config_path, 'rb') as f:
-        config = tomli.load(f)
+        config = tomllib.load(f)
 
     # Recursively process all string values
     def process_value(val):


### PR DESCRIPTION
- Replace tomli with built-in tomllib (Python 3.11+)
- Remove tomli dependency from pyproject.toml
- Update requires-python to >=3.11
- Add --quiet flag to uv run to suppress build messages
- Fix SSH reconnection output to print on separate lines
- Add visual feedback while testing SSH port