### PR TITLE
Fix report.env file generation - remove stderr redirect

### DIFF
--- a/deploy_cowrie_honeypot.sh
+++ b/deploy_cowrie_honeypot.sh
@@ -572,9 +572,9 @@ if [ "$ENABLE_REPORTING" = "true" ] && [ -f "$MASTER_CONFIG" ]; then
     # Process master config to generate server config
     echo "[*] Processing master-config.toml..."
     if command -v uv &> /dev/null; then
-        uv run --quiet scripts/process-config.py "$MASTER_CONFIG" > /tmp/server-report.env 2>&1
+        uv run --quiet scripts/process-config.py "$MASTER_CONFIG" > /tmp/server-report.env
     elif command -v python3 &> /dev/null; then
-        python3 scripts/process-config.py "$MASTER_CONFIG" > /tmp/server-report.env 2>&1
+        python3 scripts/process-config.py "$MASTER_CONFIG" > /tmp/server-report.env
     else
         echo "[!] Error: Neither uv nor python3 found. Cannot process config."
         echo "[!] Skipping automated reporting setup."


### PR DESCRIPTION
Fixes #14

Removes `2>&1` redirect when calling process-config.py to prevent informational messages printed to stderr from being included in the generated report.env file.

**Changes:**
- Remove stderr redirect from process-config.py calls in deploy_cowrie_honeypot.sh

**Testing:**
The first line of /opt/cowrie/etc/report.env will now properly start with environment variable definitions instead of containing "[*] Processing config: ./master-config.toml"