### PR TITLE
Use Debian default location for MaxMind GeoIP databases

### DIFF
--- a/deploy_cowrie_honeypot.sh
+++ b/deploy_cowrie_honeypot.sh
@@ -474,16 +474,16 @@ set -e
 DEBIAN_FRONTEND=noninteractive apt-get update -qq > /dev/null
 DEBIAN_FRONTEND=noninteractive apt-get install -qq -y geoipupdate > /dev/null
 
-# Create GeoIP config
+# Create GeoIP config using Debian default location
 cat > /etc/GeoIP.conf << 'EOF'
 AccountID $MAXMIND_ACCOUNT_ID
 LicenseKey $MAXMIND_LICENSE_KEY
 EditionIDs GeoLite2-City GeoLite2-ASN
-DatabaseDirectory /opt/cowrie/geoip
+DatabaseDirectory /var/lib/GeoIP
 EOF
 
-# Download databases
-mkdir -p /opt/cowrie/geoip
+# Create directory and download databases
+mkdir -p /var/lib/GeoIP
 geoipupdate
 
 # Set up weekly auto-updates (Wednesdays at 3 AM)

--- a/example-config.toml
+++ b/example-config.toml
@@ -76,7 +76,7 @@ report_hours = 24
 # Paths (usually don't need to change these)
 log_path = "/var/lib/docker/volumes/cowrie-var/_data/log/cowrie/cowrie.json"
 download_path = "/var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/downloads"
-geoip_db_path = "/opt/cowrie/geoip/GeoLite2-City.mmdb"
-geoip_asn_path = "/opt/cowrie/geoip/GeoLite2-ASN.mmdb"
+geoip_db_path = "/var/lib/GeoIP/GeoLite2-City.mmdb"
+geoip_asn_path = "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
 yara_rules_path = "/opt/cowrie/yara-rules"
 cache_db_path = "/opt/cowrie/var/report-cache.db"


### PR DESCRIPTION
Fixes #10

Change MaxMind GeoIP database location from /opt/cowrie/geoip to the Debian default location /var/lib/GeoIP.

**Changes:**
- Updated /etc/GeoIP.conf to use DatabaseDirectory /var/lib/GeoIP
- Updated example-config.toml paths to reflect new location
- Follows Debian package conventions for geoipupdate

**Benefits:**
- Consistent with Debian system standards
- Better integration with system package management
- Easier troubleshooting using standard Debian paths