### PR TITLE
fix: Update all references from /opt/cowrie/geoip to /var/lib/GeoIP

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -63,16 +63,8 @@ Sign up for a free MaxMind account: https://www.maxmind.com/en/geolite2/signup
 Download the databases:
 
 ```bash
-# Create directory
-mkdir -p /opt/cowrie/geoip
+# GeoIP databases are stored in Debian default location: /var/lib/GeoIP
 
-# Download GeoLite2-City and GeoLite2-ASN (requires MaxMind account)
-# Method 1: Manual download from MaxMind website
-#   - Download GeoLite2-City.mmdb
-#   - Download GeoLite2-ASN.mmdb
-#   - Place in /opt/cowrie/geoip/
-
-# Method 2: Using geoipupdate tool (recommended for automatic updates)
 # Install geoipupdate
 apt-get install -y geoipupdate
 
@@ -80,9 +72,8 @@ apt-get install -y geoipupdate
 # Then run:
 geoipupdate
 
-# Copy databases to cowrie directory
-cp /usr/share/GeoIP/GeoLite2-City.mmdb /opt/cowrie/geoip/
-cp /usr/share/GeoIP/GeoLite2-ASN.mmdb /opt/cowrie/geoip/
+# Databases are automatically downloaded to /var/lib/GeoIP/
+# (Debian default location - no need to copy)
 ```
 
 ### 3. Download YARA Rules
@@ -117,8 +108,8 @@ Create `/opt/cowrie/etc/report.env`:
 # Paths
 export COWRIE_LOG_PATH="/var/lib/docker/volumes/cowrie-var/_data/log/cowrie/cowrie.json"
 export COWRIE_DOWNLOAD_PATH="/var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/downloads"
-export GEOIP_DB_PATH="/opt/cowrie/geoip/GeoLite2-City.mmdb"
-export GEOIP_ASN_PATH="/opt/cowrie/geoip/GeoLite2-ASN.mmdb"
+export GEOIP_DB_PATH="/var/lib/GeoIP/GeoLite2-City.mmdb"
+export GEOIP_ASN_PATH="/var/lib/GeoIP/GeoLite2-ASN.mmdb"
 export YARA_RULES_PATH="/opt/cowrie/yara-rules"
 export CACHE_DB_PATH="/opt/cowrie/var/report-cache.db"
 
@@ -217,8 +208,8 @@ Create `/opt/cowrie/etc/report-config.json`:
 {
   "log_path": "/var/lib/docker/volumes/cowrie-var/_data/log/cowrie/cowrie.json",
   "download_path": "/var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/downloads",
-  "geoip_db_path": "/opt/cowrie/geoip/GeoLite2-City.mmdb",
-  "geoip_asn_path": "/opt/cowrie/geoip/GeoLite2-ASN.mmdb",
+  "geoip_db_path": "/var/lib/GeoIP/GeoLite2-City.mmdb",
+  "geoip_asn_path": "/var/lib/GeoIP/GeoLite2-ASN.mmdb",
   "yara_rules_path": "/opt/cowrie/yara-rules",
   "cache_db_path": "/opt/cowrie/var/report-cache.db",
 
@@ -323,8 +314,8 @@ docker logs cowrie
 
 ### GeoIP errors
 ```bash
-# Verify database files exist
-ls -la /opt/cowrie/geoip/
+# Verify database files exist (Debian default location)
+ls -la /var/lib/GeoIP/
 
 # Download databases if missing
 # See installation section above

--- a/scripts/daily-report.py
+++ b/scripts/daily-report.py
@@ -49,8 +49,8 @@ class Config:
             # Paths
             'log_path': os.getenv('COWRIE_LOG_PATH', '/var/lib/docker/volumes/cowrie-var/_data/log/cowrie/cowrie.json'),
             'download_path': os.getenv('COWRIE_DOWNLOAD_PATH', '/var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/downloads'),
-            'geoip_db_path': os.getenv('GEOIP_DB_PATH', '/opt/cowrie/geoip/GeoLite2-City.mmdb'),
-            'geoip_asn_path': os.getenv('GEOIP_ASN_PATH', '/opt/cowrie/geoip/GeoLite2-ASN.mmdb'),
+            'geoip_db_path': os.getenv('GEOIP_DB_PATH', '/var/lib/GeoIP/GeoLite2-City.mmdb'),
+            'geoip_asn_path': os.getenv('GEOIP_ASN_PATH', '/var/lib/GeoIP/GeoLite2-ASN.mmdb'),
             'yara_rules_path': os.getenv('YARA_RULES_PATH', '/opt/cowrie/yara-rules'),
             'cache_db_path': os.getenv('CACHE_DB_PATH', '/opt/cowrie/var/report-cache.db'),
 

--- a/scripts/report-config.example.json
+++ b/scripts/report-config.example.json
@@ -3,8 +3,8 @@
 
   "log_path": "/var/lib/docker/volumes/cowrie-var/_data/log/cowrie/cowrie.json",
   "download_path": "/var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/downloads",
-  "geoip_db_path": "/opt/cowrie/geoip/GeoLite2-City.mmdb",
-  "geoip_asn_path": "/opt/cowrie/geoip/GeoLite2-ASN.mmdb",
+  "geoip_db_path": "/var/lib/GeoIP/GeoLite2-City.mmdb",
+  "geoip_asn_path": "/var/lib/GeoIP/GeoLite2-ASN.mmdb",
   "yara_rules_path": "/opt/cowrie/yara-rules",
   "cache_db_path": "/opt/cowrie/var/report-cache.db",
 

--- a/scripts/report.env.example
+++ b/scripts/report.env.example
@@ -5,8 +5,8 @@
 # Paths
 export COWRIE_LOG_PATH="/var/lib/docker/volumes/cowrie-var/_data/log/cowrie/cowrie.json"
 export COWRIE_DOWNLOAD_PATH="/var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/downloads"
-export GEOIP_DB_PATH="/opt/cowrie/geoip/GeoLite2-City.mmdb"
-export GEOIP_ASN_PATH="/opt/cowrie/geoip/GeoLite2-ASN.mmdb"
+export GEOIP_DB_PATH="/var/lib/GeoIP/GeoLite2-City.mmdb"
+export GEOIP_ASN_PATH="/var/lib/GeoIP/GeoLite2-ASN.mmdb"
 export YARA_RULES_PATH="/opt/cowrie/yara-rules"
 export CACHE_DB_PATH="/opt/cowrie/var/report-cache.db"
 

--- a/scripts/setup-reporting.sh
+++ b/scripts/setup-reporting.sh
@@ -88,14 +88,13 @@ echo "[*] Creating directory structure..."
 
 mkdir -p /opt/cowrie/scripts
 mkdir -p /opt/cowrie/etc
-mkdir -p /opt/cowrie/geoip
 mkdir -p /opt/cowrie/yara-rules
 mkdir -p /opt/cowrie/var
 
 echo "[*] Directory structure created"
 
-# Check if databases already exist
-if [ -f "/opt/cowrie/geoip/GeoLite2-City.mmdb" ] && [ -f "/opt/cowrie/geoip/GeoLite2-ASN.mmdb" ]; then
+# Check if databases already exist (Debian default location)
+if [ -f "/var/lib/GeoIP/GeoLite2-City.mmdb" ] && [ -f "/var/lib/GeoIP/GeoLite2-ASN.mmdb" ]; then
     echo "[*] GeoIP databases found!"
 else
     echo "[!] GeoIP databases not found. Please complete steps above."
@@ -153,8 +152,8 @@ if [ ! -f "/opt/cowrie/etc/report.env" ]; then
 # Paths
 export COWRIE_LOG_PATH="/var/lib/docker/volumes/cowrie-var/_data/log/cowrie/cowrie.json"
 export COWRIE_DOWNLOAD_PATH="/var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/downloads"
-export GEOIP_DB_PATH="/opt/cowrie/geoip/GeoLite2-City.mmdb"
-export GEOIP_ASN_PATH="/opt/cowrie/geoip/GeoLite2-ASN.mmdb"
+export GEOIP_DB_PATH="/var/lib/GeoIP/GeoLite2-City.mmdb"
+export GEOIP_ASN_PATH="/var/lib/GeoIP/GeoLite2-ASN.mmdb"
 export YARA_RULES_PATH="/opt/cowrie/yara-rules"
 export CACHE_DB_PATH="/opt/cowrie/var/report-cache.db"
 
@@ -235,7 +234,7 @@ fi
 
 # Test GeoIP databases
 echo -n "[*] Testing GeoIP databases... "
-if [ -f "/opt/cowrie/geoip/GeoLite2-City.mmdb" ]; then
+if [ -f "/var/lib/GeoIP/GeoLite2-City.mmdb" ]; then
     echo "OK"
 else
     echo "NOT FOUND (requires manual setup)"


### PR DESCRIPTION
Complete the migration to Debian default GeoIP location by updating:
- scripts/setup-reporting.sh (directory creation and tests)
- scripts/report.env.example (default paths)
- scripts/daily-report.py (default paths)
- scripts/report-config.example.json (default paths)
- scripts/README.md (documentation and examples)

This ensures consistency across all files and documentation.