### PR TITLE
Add SSH session playback web dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,39 @@ COWRIE_SSH_PORT="22"             # Honeypot listens here
 REAL_SSH_PORT="2222"             # Management SSH
 ```
 
+## Web Dashboard (SSH Session Playback)
+
+The toolkit includes an optional web dashboard for viewing and replaying SSH sessions:
+
+- **Dashboard** - Overview of attack statistics, top countries, credentials, and commands
+- **Session Browser** - List all sessions with filtering and search
+- **TTY Playback** - Watch recorded SSH sessions with asciinema-player
+- **Downloads Viewer** - Browse captured malware with VirusTotal links
+
+### Enabling the Web Dashboard
+
+Add to `master-config.toml`:
+
+```toml
+[web_dashboard]
+enabled = true
+base_url = ""  # Optional: for links in email reports
+```
+
+### Accessing the Web Dashboard
+
+The web dashboard is NOT exposed to the public internet. Access via SSH tunnel:
+
+```bash
+# Create SSH tunnel
+ssh -p 2222 -L 5000:localhost:5000 root@<SERVER_IP>
+
+# Then open in browser
+open http://localhost:5000
+```
+
+For persistent access, use Tailscale (see `web/README.md`).
+
 ## Accessing the Deployed Honeypot
 
 ```bash
@@ -125,6 +158,9 @@ ssh -p 2222 root@<SERVER_IP> 'tail -f /var/lib/docker/volumes/cowrie-var/_data/l
 
 # View JSON logs (for parsing)
 ssh -p 2222 root@<SERVER_IP> 'tail -f /var/lib/docker/volumes/cowrie-var/_data/log/cowrie/cowrie.json'
+
+# View TTY session recordings
+ssh -p 2222 root@<SERVER_IP> 'ls -la /var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/tty/'
 
 # View downloaded malware
 ssh -p 2222 root@<SERVER_IP> 'ls -la /var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/downloads/'

--- a/example-config.toml
+++ b/example-config.toml
@@ -69,6 +69,22 @@ smtp_tls = true
 alert_threshold_connections = 100
 alert_on_malware = true
 
+[web_dashboard]
+# SSH Session Playback Web Service
+# Provides a web UI for viewing session details and replaying TTY recordings
+# Access is via Tailscale or SSH tunnel only (never exposed to public internet)
+enabled = false
+
+# Tailscale auth key for secure remote access (recommended)
+# Generate at: https://login.tailscale.com/admin/settings/keys
+# Use an ephemeral, reusable key with appropriate tags
+# tailscale_authkey = "op read op://Personal/Tailscale/honeypot_authkey"
+
+# Base URL for session links in email reports
+# Example: "https://honeypot-dashboard.your-tailnet.ts.net"
+# Leave empty to use relative links
+base_url = ""
+
 [advanced]
 # Report generation interval (hours)
 report_hours = 24
@@ -76,6 +92,7 @@ report_hours = 24
 # Paths (usually don't need to change these)
 log_path = "/var/lib/docker/volumes/cowrie-var/_data/log/cowrie/cowrie.json"
 download_path = "/var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/downloads"
+tty_path = "/var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/tty"
 geoip_db_path = "/var/lib/GeoIP/GeoLite2-City.mmdb"
 geoip_asn_path = "/var/lib/GeoIP/GeoLite2-ASN.mmdb"
 yara_rules_path = "/opt/cowrie/yara-rules"

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,45 @@
+# Cowrie SSH Session Playback Web Service
+FROM python:3.12-slim
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV FLASK_APP=app.py
+ENV FLASK_ENV=production
+
+# Create non-root user
+RUN groupadd -r cowrie && useradd -r -g cowrie cowrie
+
+# Set work directory
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Create directory for static files
+RUN mkdir -p /app/static /app/templates
+
+# Change ownership
+RUN chown -R cowrie:cowrie /app
+
+# Switch to non-root user
+USER cowrie
+
+# Expose port
+EXPOSE 5000
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:5000/ || exit 1
+
+# Run with gunicorn for production
+CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "2", "--threads", "4", "--timeout", "120", "app:app"]

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,175 @@
+# Cowrie SSH Session Playback Web Service
+
+A Flask-based web application for viewing and replaying SSH sessions captured by Cowrie honeypot.
+
+## Features
+
+- **Dashboard** - Overview of attack statistics, top countries, credentials, and commands
+- **Session Browser** - List all sessions with filtering and search
+- **Session Details** - View full session info including IP, location, credentials, and commands
+- **TTY Playback** - Watch recorded SSH sessions with asciinema-player
+- **Downloads Viewer** - Browse captured malware with VirusTotal links
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Web Service Architecture                      │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  Docker Network (cowrie-internal)                               │
+│  ┌─────────────────────┐    ┌─────────────────────────────────┐ │
+│  │   cowrie            │    │   cowrie-web                    │ │
+│  │   (honeypot)        │    │   (session viewer)              │ │
+│  │   Port 22 → 2222    │    │   Port 5000 (internal)          │ │
+│  └──────────┬──────────┘    └──────────────┬──────────────────┘ │
+│             │                              │                     │
+│             ▼                              ▼                     │
+│  ┌──────────────────────────────────────────────────────────┐   │
+│  │              cowrie-var volume (shared)                  │   │
+│  │  ├── log/cowrie/cowrie.json   (session events)           │   │
+│  │  ├── lib/cowrie/tty/          (TTY recordings)           │   │
+│  │  └── lib/cowrie/downloads/    (malware samples)          │   │
+│  └──────────────────────────────────────────────────────────┘   │
+│                                                                  │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Security
+
+**The web service is NOT exposed to the public internet.**
+
+Access methods:
+1. **SSH Tunnel** (recommended for occasional access)
+2. **Tailscale** (recommended for regular access)
+
+### SSH Tunnel Access
+
+```bash
+# Create SSH tunnel from your local machine
+ssh -p 2222 -L 5000:localhost:5000 root@<HONEYPOT_IP>
+
+# Then access in browser
+open http://localhost:5000
+```
+
+### Tailscale Access
+
+1. Create a Tailscale auth key at https://login.tailscale.com/admin/settings/keys
+2. Add to your `master-config.toml`:
+
+```toml
+[web_dashboard]
+enabled = true
+tailscale_authkey = "tskey-auth-..."
+```
+
+3. After deployment, access via: `https://honeypot-dashboard.<your-tailnet>.ts.net`
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `COWRIE_LOG_PATH` | `/cowrie-data/log/cowrie/cowrie.json` | Path to Cowrie JSON log |
+| `COWRIE_TTY_PATH` | `/cowrie-data/lib/cowrie/tty` | Path to TTY recordings |
+| `COWRIE_DOWNLOAD_PATH` | `/cowrie-data/lib/cowrie/downloads` | Path to downloaded files |
+| `GEOIP_DB_PATH` | `/cowrie-data/geoip/GeoLite2-City.mmdb` | Path to GeoIP database |
+| `BASE_URL` | `` | Base URL for links in reports |
+
+### Enabling TTY Recording
+
+TTY recording must be enabled in Cowrie's configuration. The deployment script automatically enables this when web dashboard is configured.
+
+In `cowrie.cfg`:
+```ini
+[output_playlog]
+enabled = true
+logfile = var/lib/cowrie/tty/{session}_{timestamp}.log
+```
+
+## API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /` | Dashboard with statistics |
+| `GET /sessions` | Session list with filters |
+| `GET /session/<id>` | Session details |
+| `GET /session/<id>/playback` | TTY playback page |
+| `GET /downloads` | Downloaded files list |
+| `GET /api/stats` | JSON stats for dashboard |
+| `GET /api/sessions` | JSON session list |
+| `GET /api/session/<id>/asciicast` | Asciicast data for player |
+
+## Local Development
+
+```bash
+# Install dependencies
+cd web
+pip install -r requirements.txt
+
+# Set environment variables
+export COWRIE_LOG_PATH=/path/to/cowrie.json
+export COWRIE_TTY_PATH=/path/to/tty
+
+# Run development server
+python app.py
+```
+
+## Docker Build
+
+```bash
+# Build image
+cd web
+docker build -t cowrie-web:local .
+
+# Run standalone
+docker run -d \
+  -p 5000:5000 \
+  -v /var/lib/docker/volumes/cowrie-var/_data:/cowrie-data:ro \
+  cowrie-web:local
+```
+
+## Integration with Daily Reports
+
+When web dashboard is enabled, daily email reports include links to session details:
+
+```
+Most Active Sessions:
+- Session abc123... (45 commands) → https://honeypot-dashboard.ts.net/session/abc123
+- Session def456... (32 commands) → https://honeypot-dashboard.ts.net/session/def456
+```
+
+Configure the base URL in `master-config.toml`:
+
+```toml
+[web_dashboard]
+enabled = true
+base_url = "https://honeypot-dashboard.your-tailnet.ts.net"
+```
+
+## Screenshots
+
+### Dashboard
+![Dashboard](docs/dashboard.png)
+
+### Session Playback
+![Playback](docs/playback.png)
+
+### Session Details
+![Details](docs/details.png)
+
+## Troubleshooting
+
+### No sessions showing
+- Check if Cowrie is logging: `tail -f /var/lib/docker/volumes/cowrie-var/_data/log/cowrie/cowrie.json`
+- Verify volume mount is correct
+
+### TTY playback not working
+- Ensure `[output_playlog]` is enabled in cowrie.cfg
+- Check if TTY files exist: `ls /var/lib/docker/volumes/cowrie-var/_data/lib/cowrie/tty/`
+
+### GeoIP not working
+- Verify MaxMind database exists: `ls /opt/cowrie/geoip/`
+- Check GeoIP auto-update cron: `crontab -l | grep geoip`

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,0 +1,8 @@
+"""
+Cowrie SSH Session Playback Web Service
+
+A Flask-based web application for viewing and replaying Cowrie honeypot SSH sessions.
+Designed to be exposed via Tailscale for secure private access.
+"""
+
+__version__ = "1.0.0"

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""
+Cowrie SSH Session Playback Web Service
+
+Provides a web interface for viewing and replaying SSH sessions captured by Cowrie.
+"""
+
+import json
+import os
+import struct
+import time
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+from flask import Flask, Response, jsonify, render_template, request
+
+try:
+    import geoip2.database
+except ImportError:
+    geoip2 = None
+
+app = Flask(__name__)
+
+# Configuration from environment variables
+CONFIG = {
+    'log_path': os.getenv('COWRIE_LOG_PATH', '/cowrie-data/log/cowrie/cowrie.json'),
+    'tty_path': os.getenv('COWRIE_TTY_PATH', '/cowrie-data/lib/cowrie/tty'),
+    'download_path': os.getenv('COWRIE_DOWNLOAD_PATH', '/cowrie-data/lib/cowrie/downloads'),
+    'geoip_db_path': os.getenv('GEOIP_DB_PATH', '/cowrie-data/geoip/GeoLite2-City.mmdb'),
+    'base_url': os.getenv('BASE_URL', ''),
+}
+
+
+class GeoIPLookup:
+    """Simple GeoIP lookup wrapper."""
+
+    def __init__(self, db_path: str):
+        self.reader = None
+        if geoip2 and os.path.exists(db_path):
+            try:
+                self.reader = geoip2.database.Reader(db_path)
+            except Exception:
+                pass
+
+    def lookup(self, ip: str) -> dict:
+        """Lookup IP and return geo data."""
+        result = {'country': 'Unknown', 'country_code': 'XX', 'city': 'Unknown'}
+        if not self.reader:
+            return result
+        try:
+            response = self.reader.city(ip)
+            result['country'] = response.country.name or 'Unknown'
+            result['country_code'] = response.country.iso_code or 'XX'
+            result['city'] = response.city.name or 'Unknown'
+        except Exception:
+            pass
+        return result
+
+
+class SessionParser:
+    """Parse Cowrie JSON logs and extract session data."""
+
+    def __init__(self, log_path: str):
+        self.log_path = log_path
+        self.sessions = {}
+        self.geoip = GeoIPLookup(CONFIG['geoip_db_path'])
+
+    def parse_all(self, hours: int = 168) -> dict:
+        """Parse all sessions from logs within the specified hours."""
+        cutoff_time = datetime.now(timezone.utc) - timedelta(hours=hours)
+        sessions = defaultdict(lambda: {
+            'id': None,
+            'src_ip': None,
+            'start_time': None,
+            'end_time': None,
+            'duration': 0,
+            'username': None,
+            'password': None,
+            'commands': [],
+            'downloads': [],
+            'tty_log': None,
+            'client_version': None,
+            'geo': {},
+            'login_success': False,
+        })
+
+        if not os.path.exists(self.log_path):
+            return {}
+
+        with open(self.log_path, 'r') as f:
+            for line in f:
+                try:
+                    entry = json.loads(line.strip())
+                    timestamp = datetime.fromisoformat(entry['timestamp'].replace('Z', '+00:00'))
+
+                    if timestamp < cutoff_time:
+                        continue
+
+                    session_id = entry.get('session')
+                    if not session_id:
+                        continue
+
+                    event_id = entry.get('eventid', '')
+                    session = sessions[session_id]
+                    session['id'] = session_id
+
+                    if event_id == 'cowrie.session.connect':
+                        session['src_ip'] = entry.get('src_ip')
+                        session['start_time'] = entry['timestamp']
+                        session['client_version'] = entry.get('version')
+                        if session['src_ip']:
+                            session['geo'] = self.geoip.lookup(session['src_ip'])
+
+                    elif event_id == 'cowrie.login.success':
+                        session['username'] = entry.get('username')
+                        session['password'] = entry.get('password')
+                        session['login_success'] = True
+
+                    elif event_id == 'cowrie.login.failed':
+                        if not session['username']:
+                            session['username'] = entry.get('username')
+                            session['password'] = entry.get('password')
+
+                    elif event_id == 'cowrie.command.input':
+                        session['commands'].append({
+                            'command': entry.get('input', ''),
+                            'timestamp': entry['timestamp']
+                        })
+
+                    elif event_id == 'cowrie.session.file_download':
+                        session['downloads'].append({
+                            'url': entry.get('url', ''),
+                            'shasum': entry.get('shasum', ''),
+                            'timestamp': entry['timestamp']
+                        })
+
+                    elif event_id == 'cowrie.log.closed':
+                        tty_log = entry.get('ttylog')
+                        if tty_log:
+                            session['tty_log'] = tty_log
+
+                    elif event_id == 'cowrie.session.closed':
+                        session['end_time'] = entry['timestamp']
+                        if session['start_time']:
+                            start = datetime.fromisoformat(session['start_time'].replace('Z', '+00:00'))
+                            end = datetime.fromisoformat(session['end_time'].replace('Z', '+00:00'))
+                            session['duration'] = (end - start).total_seconds()
+
+                except (json.JSONDecodeError, KeyError, ValueError):
+                    continue
+
+        return dict(sessions)
+
+    def get_session(self, session_id: str) -> Optional[dict]:
+        """Get a specific session by ID."""
+        sessions = self.parse_all(hours=720)  # Look back 30 days
+        return sessions.get(session_id)
+
+    def get_stats(self, hours: int = 24) -> dict:
+        """Get statistics for the dashboard."""
+        sessions = self.parse_all(hours=hours)
+
+        if not sessions:
+            return {
+                'total_sessions': 0,
+                'unique_ips': 0,
+                'sessions_with_commands': 0,
+                'total_downloads': 0,
+                'top_countries': [],
+                'top_credentials': [],
+                'top_commands': [],
+                'hourly_activity': [],
+            }
+
+        # Calculate stats
+        ips = set()
+        country_counter = Counter()
+        credential_counter = Counter()
+        command_counter = Counter()
+        sessions_with_cmds = 0
+        total_downloads = 0
+        hourly_activity = defaultdict(int)
+
+        for session in sessions.values():
+            if session['src_ip']:
+                ips.add(session['src_ip'])
+                country = session.get('geo', {}).get('country', 'Unknown')
+                country_counter[country] += 1
+
+            if session['username'] and session['password']:
+                cred = f"{session['username']}:{session['password']}"
+                credential_counter[cred] += 1
+
+            if session['commands']:
+                sessions_with_cmds += 1
+                for cmd in session['commands']:
+                    command_counter[cmd['command']] += 1
+
+            total_downloads += len(session['downloads'])
+
+            if session['start_time']:
+                try:
+                    hour = datetime.fromisoformat(
+                        session['start_time'].replace('Z', '+00:00')
+                    ).strftime('%Y-%m-%d %H:00')
+                    hourly_activity[hour] += 1
+                except Exception:
+                    pass
+
+        # Sort hourly activity
+        sorted_hours = sorted(hourly_activity.items())
+
+        return {
+            'total_sessions': len(sessions),
+            'unique_ips': len(ips),
+            'sessions_with_commands': sessions_with_cmds,
+            'total_downloads': total_downloads,
+            'top_countries': country_counter.most_common(10),
+            'top_credentials': credential_counter.most_common(10),
+            'top_commands': command_counter.most_common(20),
+            'hourly_activity': sorted_hours[-48:],  # Last 48 hours
+        }
+
+
+class TTYLogParser:
+    """Parse Cowrie TTY log files and convert to asciicast format."""
+
+    # Cowrie TTY log opcodes
+    OP_OPEN = 1
+    OP_CLOSE = 2
+    OP_WRITE = 3
+    OP_EXEC = 4
+
+    def __init__(self, tty_path: str):
+        self.tty_path = tty_path
+
+    def find_tty_file(self, tty_log_name: str) -> Optional[str]:
+        """Find a TTY log file by name."""
+        if not tty_log_name:
+            return None
+
+        # Try direct path
+        direct_path = os.path.join(self.tty_path, tty_log_name)
+        if os.path.exists(direct_path):
+            return direct_path
+
+        # Try with various date-based subdirectories
+        for root, dirs, files in os.walk(self.tty_path):
+            if tty_log_name in files:
+                return os.path.join(root, tty_log_name)
+
+        return None
+
+    def parse_tty_log(self, tty_log_name: str) -> Optional[dict]:
+        """Parse a Cowrie TTY log file and return asciicast v2 format."""
+        file_path = self.find_tty_file(tty_log_name)
+        if not file_path:
+            return None
+
+        events = []
+        start_time = None
+        width = 80
+        height = 24
+
+        try:
+            with open(file_path, 'rb') as f:
+                while True:
+                    # Read header: opcode (4 bytes), time (4 bytes), size (4 bytes)
+                    header = f.read(12)
+                    if len(header) < 12:
+                        break
+
+                    opcode, ts, size = struct.unpack('<III', header)
+                    data = f.read(size)
+
+                    if opcode == self.OP_OPEN:
+                        start_time = ts / 1000000.0  # Convert to seconds
+                        # Try to parse terminal size from data
+                        try:
+                            if len(data) >= 8:
+                                width, height = struct.unpack('<II', data[:8])
+                        except Exception:
+                            pass
+
+                    elif opcode == self.OP_WRITE:
+                        if start_time is not None:
+                            relative_time = (ts / 1000000.0) - start_time
+                            # Decode data, replacing invalid bytes
+                            try:
+                                text = data.decode('utf-8', errors='replace')
+                            except Exception:
+                                text = data.decode('latin-1', errors='replace')
+                            events.append([relative_time, 'o', text])
+
+                    elif opcode == self.OP_CLOSE:
+                        break
+
+        except Exception as e:
+            return None
+
+        if not events:
+            return None
+
+        # Return asciicast v2 format
+        return {
+            'version': 2,
+            'width': min(width, 200),
+            'height': min(height, 50),
+            'timestamp': int(start_time) if start_time else int(time.time()),
+            'env': {'SHELL': '/bin/bash', 'TERM': 'xterm-256color'},
+            'events': events
+        }
+
+    def get_asciicast_ndjson(self, tty_log_name: str) -> Optional[str]:
+        """Get TTY log as asciicast v2 NDJSON format."""
+        data = self.parse_tty_log(tty_log_name)
+        if not data:
+            return None
+
+        lines = []
+        # Header line
+        header = {
+            'version': data['version'],
+            'width': data['width'],
+            'height': data['height'],
+            'timestamp': data['timestamp'],
+            'env': data['env']
+        }
+        lines.append(json.dumps(header))
+
+        # Event lines
+        for event in data['events']:
+            lines.append(json.dumps(event))
+
+        return '\n'.join(lines)
+
+
+# Initialize parsers
+session_parser = SessionParser(CONFIG['log_path'])
+tty_parser = TTYLogParser(CONFIG['tty_path'])
+
+
+@app.route('/')
+def index():
+    """Dashboard page."""
+    hours = request.args.get('hours', 24, type=int)
+    stats = session_parser.get_stats(hours=hours)
+    return render_template('index.html', stats=stats, hours=hours, config=CONFIG)
+
+
+@app.route('/sessions')
+def sessions():
+    """Session listing page."""
+    hours = request.args.get('hours', 168, type=int)
+    page = request.args.get('page', 1, type=int)
+    per_page = 50
+
+    all_sessions = session_parser.parse_all(hours=hours)
+
+    # Sort by start time (most recent first)
+    sorted_sessions = sorted(
+        all_sessions.values(),
+        key=lambda x: x['start_time'] or '',
+        reverse=True
+    )
+
+    # Filter options
+    ip_filter = request.args.get('ip', '')
+    has_commands = request.args.get('has_commands', '')
+    has_tty = request.args.get('has_tty', '')
+
+    if ip_filter:
+        sorted_sessions = [s for s in sorted_sessions if s['src_ip'] == ip_filter]
+    if has_commands == '1':
+        sorted_sessions = [s for s in sorted_sessions if s['commands']]
+    if has_tty == '1':
+        sorted_sessions = [s for s in sorted_sessions if s['tty_log']]
+
+    # Paginate
+    total = len(sorted_sessions)
+    start = (page - 1) * per_page
+    end = start + per_page
+    paginated = sorted_sessions[start:end]
+
+    return render_template(
+        'sessions.html',
+        sessions=paginated,
+        page=page,
+        per_page=per_page,
+        total=total,
+        hours=hours,
+        ip_filter=ip_filter,
+        has_commands=has_commands,
+        has_tty=has_tty,
+        config=CONFIG
+    )
+
+
+@app.route('/session/<session_id>')
+def session_detail(session_id: str):
+    """Session detail page."""
+    session = session_parser.get_session(session_id)
+    if not session:
+        return render_template('404.html', message='Session not found'), 404
+
+    # Check if TTY log exists
+    has_tty = False
+    if session['tty_log']:
+        tty_file = tty_parser.find_tty_file(session['tty_log'])
+        has_tty = tty_file is not None
+
+    return render_template('session_detail.html', session=session, has_tty=has_tty, config=CONFIG)
+
+
+@app.route('/session/<session_id>/playback')
+def session_playback(session_id: str):
+    """Session playback page with asciinema player."""
+    session = session_parser.get_session(session_id)
+    if not session:
+        return render_template('404.html', message='Session not found'), 404
+
+    if not session['tty_log']:
+        return render_template('404.html', message='No TTY recording for this session'), 404
+
+    return render_template('playback.html', session=session, config=CONFIG)
+
+
+@app.route('/api/session/<session_id>/asciicast')
+def session_asciicast(session_id: str):
+    """Return asciicast data for a session."""
+    session = session_parser.get_session(session_id)
+    if not session or not session['tty_log']:
+        return jsonify({'error': 'No TTY recording'}), 404
+
+    asciicast = tty_parser.get_asciicast_ndjson(session['tty_log'])
+    if not asciicast:
+        return jsonify({'error': 'Failed to parse TTY log'}), 500
+
+    return Response(asciicast, mimetype='application/x-asciicast')
+
+
+@app.route('/api/stats')
+def api_stats():
+    """API endpoint for dashboard stats."""
+    hours = request.args.get('hours', 24, type=int)
+    stats = session_parser.get_stats(hours=hours)
+    return jsonify(stats)
+
+
+@app.route('/api/sessions')
+def api_sessions():
+    """API endpoint for sessions list."""
+    hours = request.args.get('hours', 168, type=int)
+    limit = request.args.get('limit', 100, type=int)
+
+    all_sessions = session_parser.parse_all(hours=hours)
+    sorted_sessions = sorted(
+        all_sessions.values(),
+        key=lambda x: x['start_time'] or '',
+        reverse=True
+    )[:limit]
+
+    return jsonify(sorted_sessions)
+
+
+@app.route('/downloads')
+def downloads():
+    """Downloaded files listing page."""
+    hours = request.args.get('hours', 168, type=int)
+    all_sessions = session_parser.parse_all(hours=hours)
+
+    # Collect all downloads
+    all_downloads = []
+    for session in all_sessions.values():
+        for download in session['downloads']:
+            download['session_id'] = session['id']
+            download['src_ip'] = session['src_ip']
+            all_downloads.append(download)
+
+    # Deduplicate by shasum
+    unique_downloads = {}
+    for dl in all_downloads:
+        shasum = dl['shasum']
+        if shasum not in unique_downloads:
+            unique_downloads[shasum] = dl
+            unique_downloads[shasum]['count'] = 1
+        else:
+            unique_downloads[shasum]['count'] += 1
+
+    # Check which files exist on disk
+    download_path = CONFIG['download_path']
+    for shasum, dl in unique_downloads.items():
+        file_path = os.path.join(download_path, shasum)
+        dl['exists'] = os.path.exists(file_path)
+        if dl['exists']:
+            dl['size'] = os.path.getsize(file_path)
+        else:
+            dl['size'] = 0
+
+    downloads_list = sorted(unique_downloads.values(), key=lambda x: x['timestamp'], reverse=True)
+
+    return render_template('downloads.html', downloads=downloads_list, hours=hours, config=CONFIG)
+
+
+@app.template_filter('format_duration')
+def format_duration(seconds):
+    """Format duration in seconds to human readable string."""
+    if not seconds:
+        return 'N/A'
+    if seconds < 60:
+        return f'{int(seconds)}s'
+    elif seconds < 3600:
+        return f'{int(seconds // 60)}m {int(seconds % 60)}s'
+    else:
+        hours = int(seconds // 3600)
+        minutes = int((seconds % 3600) // 60)
+        return f'{hours}h {minutes}m'
+
+
+@app.template_filter('format_timestamp')
+def format_timestamp(ts_str):
+    """Format ISO timestamp to readable string."""
+    if not ts_str:
+        return 'N/A'
+    try:
+        dt = datetime.fromisoformat(ts_str.replace('Z', '+00:00'))
+        return dt.strftime('%Y-%m-%d %H:%M:%S UTC')
+    except Exception:
+        return ts_str
+
+
+@app.template_filter('truncate_hash')
+def truncate_hash(hash_str, length=16):
+    """Truncate a hash for display."""
+    if not hash_str:
+        return 'N/A'
+    if len(hash_str) <= length:
+        return hash_str
+    return hash_str[:length] + '...'
+
+
+if __name__ == '__main__':
+    # Development server
+    app.run(host='0.0.0.0', port=5000, debug=True)

--- a/web/docker-compose.web.yml
+++ b/web/docker-compose.web.yml
@@ -1,0 +1,108 @@
+# Docker Compose configuration for Cowrie with Web Dashboard
+# This file is used when web_dashboard is enabled in master-config.toml
+#
+# Features:
+# - Cowrie SSH honeypot on port 22
+# - Web dashboard for session playback (internal network only)
+# - Optional Tailscale sidecar for secure remote access
+#
+# The web dashboard is NOT exposed to the public internet.
+# Access is via Tailscale or SSH tunnel only.
+
+services:
+  cowrie:
+    image: cowrie/cowrie:latest
+    container_name: cowrie
+    restart: unless-stopped
+    ports:
+      - "22:2222"
+    volumes:
+      - cowrie-etc:/cowrie/cowrie-git/etc
+      - cowrie-var:/cowrie/cowrie-git/var
+      - /opt/cowrie/share:/cowrie/cowrie-git/share:ro
+    environment:
+      - COWRIE_HOSTNAME=server
+    # Security hardening
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    networks:
+      - cowrie-internal
+
+  # SSH Session Playback Web Service
+  # Accessible only via Tailscale or SSH tunnel
+  cowrie-web:
+    build:
+      context: /opt/cowrie/web
+      dockerfile: Dockerfile
+    image: cowrie-web:local
+    container_name: cowrie-web
+    restart: unless-stopped
+    # NOT exposed to public - only on internal network
+    # Access via Tailscale or SSH tunnel (ssh -L 5000:localhost:5000)
+    expose:
+      - "5000"
+    ports:
+      # Only listen on localhost for SSH tunnel access
+      - "127.0.0.1:5000:5000"
+    volumes:
+      # Mount Cowrie data read-only
+      - cowrie-var:/cowrie-data:ro
+      # Mount GeoIP database if available
+      - /opt/cowrie/geoip:/cowrie-data/geoip:ro
+    environment:
+      - COWRIE_LOG_PATH=/cowrie-data/log/cowrie/cowrie.json
+      - COWRIE_TTY_PATH=/cowrie-data/lib/cowrie/tty
+      - COWRIE_DOWNLOAD_PATH=/cowrie-data/lib/cowrie/downloads
+      - GEOIP_DB_PATH=/cowrie-data/geoip/GeoLite2-City.mmdb
+      - BASE_URL=${WEB_BASE_URL:-}
+    depends_on:
+      - cowrie
+    networks:
+      - cowrie-internal
+    # Security hardening
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp:size=10M,mode=1777
+
+  # Optional: Tailscale sidecar for secure remote access
+  # Uncomment this section if you want to use Tailscale
+  # tailscale:
+  #   image: tailscale/tailscale:stable
+  #   container_name: tailscale
+  #   hostname: honeypot-dashboard
+  #   restart: unless-stopped
+  #   environment:
+  #     - TS_AUTHKEY=${TS_AUTHKEY}
+  #     - TS_STATE_DIR=/var/lib/tailscale
+  #     - TS_SERVE_CONFIG=/config/serve.json
+  #   volumes:
+  #     - tailscale-state:/var/lib/tailscale
+  #     - /opt/cowrie/tailscale:/config:ro
+  #   cap_add:
+  #     - NET_ADMIN
+  #     - NET_RAW
+  #   devices:
+  #     - /dev/net/tun:/dev/net/tun
+  #   networks:
+  #     - cowrie-internal
+  #   depends_on:
+  #     - cowrie-web
+
+volumes:
+  cowrie-etc:
+    name: cowrie-etc
+  cowrie-var:
+    name: cowrie-var
+  # tailscale-state:
+  #   name: tailscale-state
+
+networks:
+  cowrie-internal:
+    driver: bridge

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,0 +1,13 @@
+# Cowrie SSH Session Playback Web Service - Dependencies
+
+# Web framework
+flask>=3.0.0
+
+# Production WSGI server
+gunicorn>=21.0.0
+
+# GeoIP lookups (optional, for location enrichment)
+geoip2>=4.8.0
+
+# Async support (optional)
+gevent>=23.9.0

--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -1,0 +1,633 @@
+/* Cowrie Honeypot Session Viewer - Stylesheet */
+
+:root {
+    --bg-primary: #0d1117;
+    --bg-secondary: #161b22;
+    --bg-tertiary: #21262d;
+    --text-primary: #c9d1d9;
+    --text-secondary: #8b949e;
+    --accent-primary: #58a6ff;
+    --accent-success: #3fb950;
+    --accent-warning: #d29922;
+    --accent-danger: #f85149;
+    --border-color: #30363d;
+    --card-shadow: 0 3px 6px rgba(0, 0, 0, 0.3);
+}
+
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Navigation */
+.navbar {
+    background-color: var(--bg-secondary);
+    border-bottom: 1px solid var(--border-color);
+    padding: 0 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    height: 60px;
+    position: sticky;
+    top: 0;
+    z-index: 100;
+}
+
+.nav-brand a {
+    color: var(--text-primary);
+    font-size: 1.25rem;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.nav-brand a:hover {
+    color: var(--accent-primary);
+}
+
+.nav-links {
+    display: flex;
+    gap: 5px;
+}
+
+.nav-links a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    padding: 8px 16px;
+    border-radius: 6px;
+    transition: all 0.2s;
+}
+
+.nav-links a:hover {
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+}
+
+.nav-links a.active {
+    background-color: var(--bg-tertiary);
+    color: var(--accent-primary);
+}
+
+/* Main container */
+.container {
+    flex: 1;
+    max-width: 1400px;
+    margin: 0 auto;
+    padding: 20px;
+    width: 100%;
+}
+
+/* Page header */
+.page-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 24px;
+    flex-wrap: wrap;
+    gap: 15px;
+}
+
+.page-header h1 {
+    font-size: 1.75rem;
+    font-weight: 600;
+}
+
+/* Stats cards */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 16px;
+    margin-bottom: 24px;
+}
+
+.stat-card {
+    background: linear-gradient(135deg, #238636 0%, #2ea043 100%);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+}
+
+.stat-card:nth-child(2) {
+    background: linear-gradient(135deg, #1f6feb 0%, #388bfd 100%);
+}
+
+.stat-card:nth-child(3) {
+    background: linear-gradient(135deg, #8957e5 0%, #a371f7 100%);
+}
+
+.stat-card:nth-child(4) {
+    background: linear-gradient(135deg, #db6d28 0%, #f0883e 100%);
+}
+
+.stat-value {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: white;
+}
+
+.stat-label {
+    font-size: 0.875rem;
+    color: rgba(255, 255, 255, 0.85);
+    margin-top: 4px;
+}
+
+/* Dashboard grid */
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 20px;
+    margin-bottom: 24px;
+}
+
+.dashboard-card {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 20px;
+}
+
+.dashboard-card.full-width {
+    grid-column: 1 / -1;
+}
+
+.dashboard-card h2 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin-bottom: 16px;
+    color: var(--text-primary);
+}
+
+/* Data tables */
+.data-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.data-table th {
+    background-color: var(--bg-tertiary);
+    color: var(--text-secondary);
+    font-weight: 600;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 10px 12px;
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.data-table td {
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border-color);
+    font-size: 0.875rem;
+}
+
+.data-table tr:hover {
+    background-color: var(--bg-tertiary);
+}
+
+.data-table a {
+    color: var(--accent-primary);
+    text-decoration: none;
+}
+
+.data-table a:hover {
+    text-decoration: underline;
+}
+
+/* Code and command styling */
+code {
+    font-family: 'Fira Code', 'Consolas', 'Monaco', monospace;
+    background-color: var(--bg-tertiary);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 0.85em;
+    word-break: break-all;
+}
+
+.command-text {
+    display: block;
+    max-width: 600px;
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+.url-text {
+    display: block;
+    max-width: 400px;
+    overflow-x: auto;
+    white-space: nowrap;
+}
+
+/* Buttons */
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 16px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    background-color: var(--bg-tertiary);
+    color: var(--text-primary);
+    text-decoration: none;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.btn:hover {
+    background-color: var(--bg-secondary);
+    border-color: var(--text-secondary);
+}
+
+.btn-primary {
+    background-color: var(--accent-primary);
+    border-color: var(--accent-primary);
+    color: white;
+}
+
+.btn-primary:hover {
+    background-color: #4c9aed;
+    border-color: #4c9aed;
+}
+
+.btn-sm {
+    padding: 4px 10px;
+    font-size: 0.75rem;
+}
+
+/* Badges */
+.badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    border-radius: 12px;
+    text-transform: uppercase;
+}
+
+.badge-success {
+    background-color: rgba(63, 185, 80, 0.2);
+    color: var(--accent-success);
+}
+
+.badge-warning {
+    background-color: rgba(210, 153, 34, 0.2);
+    color: var(--accent-warning);
+}
+
+.badge-danger {
+    background-color: rgba(248, 81, 73, 0.2);
+    color: var(--accent-danger);
+}
+
+/* Activity chart */
+.activity-chart {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+    height: 100px;
+    padding: 10px 0;
+}
+
+.activity-bar {
+    flex: 1;
+    background: linear-gradient(180deg, var(--accent-primary) 0%, #1f6feb 100%);
+    border-radius: 2px 2px 0 0;
+    min-height: 2px;
+    transition: all 0.2s;
+}
+
+.activity-bar:hover {
+    opacity: 0.8;
+}
+
+.chart-labels {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    padding-top: 8px;
+}
+
+/* Session detail page */
+.detail-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+    gap: 20px;
+    margin-bottom: 24px;
+}
+
+.detail-card {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 20px;
+}
+
+.detail-card.full-width {
+    grid-column: 1 / -1;
+}
+
+.detail-card h2 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.detail-list {
+    display: grid;
+    grid-template-columns: 140px 1fr;
+    gap: 8px 16px;
+}
+
+.detail-list dt {
+    font-weight: 600;
+    color: var(--text-secondary);
+    font-size: 0.875rem;
+}
+
+.detail-list dd {
+    font-size: 0.875rem;
+}
+
+/* Command list */
+.command-list {
+    max-height: 500px;
+    overflow-y: auto;
+}
+
+.command-entry {
+    display: flex;
+    gap: 16px;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.command-entry:last-child {
+    border-bottom: none;
+}
+
+.command-time {
+    color: var(--text-secondary);
+    font-size: 0.75rem;
+    white-space: nowrap;
+    min-width: 140px;
+}
+
+.command-entry code {
+    flex: 1;
+    word-break: break-all;
+    white-space: pre-wrap;
+}
+
+/* TTY info box */
+.tty-info {
+    margin-top: 20px;
+    padding: 16px;
+    background-color: var(--bg-tertiary);
+    border-radius: 8px;
+    border-left: 4px solid var(--accent-primary);
+}
+
+.tty-info h3 {
+    font-size: 1rem;
+    margin-bottom: 8px;
+}
+
+.tty-info p {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    margin-bottom: 12px;
+}
+
+/* Filters */
+.filters {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.filter-form {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.filter-form select,
+.filter-form input[type="text"] {
+    padding: 8px 12px;
+    font-size: 0.875rem;
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+}
+
+.filter-form label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+.filter-form input[type="checkbox"] {
+    accent-color: var(--accent-primary);
+}
+
+.time-filter {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.time-filter label {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+.time-filter select {
+    padding: 8px 12px;
+    font-size: 0.875rem;
+    background-color: var(--bg-tertiary);
+    border: 1px solid var(--border-color);
+    border-radius: 6px;
+    color: var(--text-primary);
+}
+
+/* Pagination */
+.pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 15px;
+    margin-top: 24px;
+    padding-top: 16px;
+    border-top: 1px solid var(--border-color);
+}
+
+.page-info {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+/* Results info */
+.results-info,
+.downloads-info {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    margin-bottom: 16px;
+}
+
+/* No data message */
+.no-data {
+    color: var(--text-secondary);
+    font-style: italic;
+    text-align: center;
+    padding: 20px;
+}
+
+/* Success login highlight */
+.success-login {
+    background-color: rgba(63, 185, 80, 0.1);
+}
+
+/* Actions column */
+.actions {
+    display: flex;
+    gap: 6px;
+}
+
+/* External link */
+.external-link {
+    font-size: 0.7rem;
+    padding: 2px 6px;
+    background-color: var(--bg-tertiary);
+    border-radius: 4px;
+    margin-left: 8px;
+}
+
+/* Error page */
+.error-page {
+    text-align: center;
+    padding: 60px 20px;
+}
+
+.error-page h1 {
+    font-size: 3rem;
+    margin-bottom: 16px;
+    color: var(--accent-danger);
+}
+
+.error-page p {
+    color: var(--text-secondary);
+    margin-bottom: 24px;
+}
+
+/* Footer */
+.footer {
+    background-color: var(--bg-secondary);
+    border-top: 1px solid var(--border-color);
+    padding: 16px;
+    text-align: center;
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+/* Header actions */
+.header-actions {
+    display: flex;
+    gap: 10px;
+}
+
+/* Playback note */
+.playback-note {
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    padding: 16px;
+    margin-top: 20px;
+}
+
+.playback-note p {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    margin: 0;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .navbar {
+        flex-direction: column;
+        height: auto;
+        padding: 10px;
+        gap: 10px;
+    }
+
+    .nav-links {
+        flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    .page-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .dashboard-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .detail-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .filter-form {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .sessions-table {
+        display: block;
+        overflow-x: auto;
+    }
+
+    .downloads-table {
+        display: block;
+        overflow-x: auto;
+    }
+}
+
+/* Scrollbar styling */
+::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: var(--bg-primary);
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--bg-tertiary);
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: var(--border-color);
+}

--- a/web/tailscale-serve.json
+++ b/web/tailscale-serve.json
@@ -1,0 +1,16 @@
+{
+  "TCP": {
+    "443": {
+      "HTTPS": true
+    }
+  },
+  "Web": {
+    "${TS_CERT_DOMAIN}:443": {
+      "Handlers": {
+        "/": {
+          "Proxy": "http://cowrie-web:5000"
+        }
+      }
+    }
+  }
+}

--- a/web/templates/404.html
+++ b/web/templates/404.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block title %}Not Found - Cowrie Honeypot{% endblock %}
+
+{% block content %}
+<div class="error-page">
+    <h1>404 - Not Found</h1>
+    <p>{{ message or 'The requested page was not found.' }}</p>
+    <a href="{{ url_for('index') }}" class="btn btn-primary">Return to Dashboard</a>
+</div>
+{% endblock %}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Cowrie Honeypot{% endblock %}</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    {% block head %}{% endblock %}
+</head>
+<body>
+    <nav class="navbar">
+        <div class="nav-brand">
+            <a href="{{ url_for('index') }}">Cowrie Dashboard</a>
+        </div>
+        <div class="nav-links">
+            <a href="{{ url_for('index') }}" class="{% if request.endpoint == 'index' %}active{% endif %}">Dashboard</a>
+            <a href="{{ url_for('sessions') }}" class="{% if request.endpoint == 'sessions' %}active{% endif %}">Sessions</a>
+            <a href="{{ url_for('downloads') }}" class="{% if request.endpoint == 'downloads' %}active{% endif %}">Downloads</a>
+        </div>
+    </nav>
+
+    <main class="container">
+        {% block content %}{% endblock %}
+    </main>
+
+    <footer class="footer">
+        <p>Cowrie Honeypot Session Viewer &bull; Accessible via Tailscale only</p>
+    </footer>
+
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/web/templates/downloads.html
+++ b/web/templates/downloads.html
@@ -1,0 +1,76 @@
+{% extends "base.html" %}
+
+{% block title %}Downloads - Cowrie Honeypot{% endblock %}
+
+{% block content %}
+<div class="downloads-page">
+    <div class="page-header">
+        <h1>Downloaded Files</h1>
+        <div class="time-filter">
+            <label>Time range:</label>
+            <select onchange="window.location.href='?hours=' + this.value">
+                <option value="24" {% if hours == 24 %}selected{% endif %}>Last 24 hours</option>
+                <option value="48" {% if hours == 48 %}selected{% endif %}>Last 48 hours</option>
+                <option value="168" {% if hours == 168 %}selected{% endif %}>Last 7 days</option>
+                <option value="720" {% if hours == 720 %}selected{% endif %}>Last 30 days</option>
+            </select>
+        </div>
+    </div>
+
+    <div class="downloads-info">
+        <p>{{ downloads | length }} unique files downloaded</p>
+    </div>
+
+    <table class="data-table downloads-table">
+        <thead>
+            <tr>
+                <th>SHA256</th>
+                <th>URL</th>
+                <th>Size</th>
+                <th>Downloads</th>
+                <th>First Seen</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for dl in downloads %}
+            <tr>
+                <td>
+                    <code title="{{ dl.shasum }}">{{ dl.shasum | truncate_hash(20) }}</code>
+                    {% if not dl.exists %}
+                    <span class="badge badge-warning" title="File not found on disk">Missing</span>
+                    {% endif %}
+                </td>
+                <td>
+                    <code class="url-text" title="{{ dl.url }}">
+                        {{ dl.url[:60] }}{% if dl.url | length > 60 %}...{% endif %}
+                    </code>
+                </td>
+                <td>
+                    {% if dl.size %}
+                    {{ (dl.size / 1024) | round(1) }} KB
+                    {% else %}
+                    N/A
+                    {% endif %}
+                </td>
+                <td>{{ dl.count }}x</td>
+                <td>{{ dl.timestamp | format_timestamp }}</td>
+                <td class="actions">
+                    <a href="https://www.virustotal.com/gui/file/{{ dl.shasum }}"
+                       target="_blank"
+                       class="btn btn-sm"
+                       title="View on VirusTotal">VT</a>
+                    <a href="{{ url_for('session_detail', session_id=dl.session_id) }}"
+                       class="btn btn-sm"
+                       title="View session">Session</a>
+                </td>
+            </tr>
+            {% else %}
+            <tr>
+                <td colspan="6" class="no-data">No downloads recorded</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endblock %}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,137 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard - Cowrie Honeypot{% endblock %}
+
+{% block content %}
+<div class="dashboard">
+    <div class="page-header">
+        <h1>Honeypot Dashboard</h1>
+        <div class="time-filter">
+            <label>Time range:</label>
+            <select onchange="window.location.href='?hours=' + this.value">
+                <option value="24" {% if hours == 24 %}selected{% endif %}>Last 24 hours</option>
+                <option value="48" {% if hours == 48 %}selected{% endif %}>Last 48 hours</option>
+                <option value="168" {% if hours == 168 %}selected{% endif %}>Last 7 days</option>
+                <option value="720" {% if hours == 720 %}selected{% endif %}>Last 30 days</option>
+            </select>
+        </div>
+    </div>
+
+    <!-- Stats Cards -->
+    <div class="stats-grid">
+        <div class="stat-card">
+            <div class="stat-value">{{ stats.total_sessions }}</div>
+            <div class="stat-label">Total Sessions</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-value">{{ stats.unique_ips }}</div>
+            <div class="stat-label">Unique IPs</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-value">{{ stats.sessions_with_commands }}</div>
+            <div class="stat-label">Sessions with Commands</div>
+        </div>
+        <div class="stat-card">
+            <div class="stat-value">{{ stats.total_downloads }}</div>
+            <div class="stat-label">Files Downloaded</div>
+        </div>
+    </div>
+
+    <div class="dashboard-grid">
+        <!-- Top Countries -->
+        <div class="dashboard-card">
+            <h2>Top Attacking Countries</h2>
+            {% if stats.top_countries %}
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Country</th>
+                        <th>Sessions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for country, count in stats.top_countries %}
+                    <tr>
+                        <td>{{ country }}</td>
+                        <td>{{ count }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p class="no-data">No data available</p>
+            {% endif %}
+        </div>
+
+        <!-- Top Credentials -->
+        <div class="dashboard-card">
+            <h2>Top Credentials Attempted</h2>
+            {% if stats.top_credentials %}
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Username:Password</th>
+                        <th>Attempts</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for cred, count in stats.top_credentials %}
+                    <tr>
+                        <td><code>{{ cred }}</code></td>
+                        <td>{{ count }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p class="no-data">No data available</p>
+            {% endif %}
+        </div>
+
+        <!-- Top Commands -->
+        <div class="dashboard-card full-width">
+            <h2>Top Commands Executed</h2>
+            {% if stats.top_commands %}
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Count</th>
+                        <th>Command</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for command, count in stats.top_commands %}
+                    <tr>
+                        <td>{{ count }}</td>
+                        <td><code class="command-text">{{ command }}</code></td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <p class="no-data">No commands recorded</p>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Activity Chart -->
+    {% if stats.hourly_activity %}
+    <div class="dashboard-card full-width">
+        <h2>Activity Over Time</h2>
+        <div class="activity-chart">
+            {% set max_activity = stats.hourly_activity | map(attribute=1) | max %}
+            {% for hour, count in stats.hourly_activity %}
+            <div class="activity-bar"
+                 style="height: {{ (count / max_activity * 100) if max_activity > 0 else 0 }}%"
+                 title="{{ hour }}: {{ count }} sessions">
+            </div>
+            {% endfor %}
+        </div>
+        <div class="chart-labels">
+            <span>{{ stats.hourly_activity[0][0] if stats.hourly_activity else '' }}</span>
+            <span>{{ stats.hourly_activity[-1][0] if stats.hourly_activity else '' }}</span>
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/web/templates/playback.html
+++ b/web/templates/playback.html
@@ -1,0 +1,141 @@
+{% extends "base.html" %}
+
+{% block title %}Playback - Session {{ session.id | truncate_hash }} - Cowrie Honeypot{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/asciinema-player@3.6.3/dist/bundle/asciinema-player.css" />
+<style>
+    .player-container {
+        max-width: 1200px;
+        margin: 0 auto;
+    }
+    .player-wrapper {
+        background: #1e1e1e;
+        border-radius: 8px;
+        overflow: hidden;
+        margin: 20px 0;
+    }
+    #player {
+        width: 100%;
+    }
+    .player-controls {
+        display: flex;
+        gap: 10px;
+        margin-bottom: 15px;
+        flex-wrap: wrap;
+    }
+    .speed-control {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+    .session-meta {
+        background: var(--bg-secondary);
+        padding: 15px;
+        border-radius: 8px;
+        margin-bottom: 20px;
+    }
+    .session-meta dl {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 10px;
+    }
+    .session-meta dt {
+        font-weight: 600;
+        color: var(--text-secondary);
+    }
+    .session-meta dd {
+        margin: 0;
+    }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="player-container">
+    <div class="page-header">
+        <h1>Session Playback</h1>
+        <a href="{{ url_for('session_detail', session_id=session.id) }}" class="btn">View Details</a>
+    </div>
+
+    <div class="session-meta">
+        <dl>
+            <div>
+                <dt>Session ID</dt>
+                <dd><code>{{ session.id | truncate_hash }}</code></dd>
+            </div>
+            <div>
+                <dt>Source IP</dt>
+                <dd>{{ session.src_ip }}</dd>
+            </div>
+            <div>
+                <dt>Location</dt>
+                <dd>{{ session.geo.country if session.geo else 'Unknown' }}</dd>
+            </div>
+            <div>
+                <dt>Duration</dt>
+                <dd>{{ session.duration | format_duration }}</dd>
+            </div>
+            <div>
+                <dt>Commands</dt>
+                <dd>{{ session.commands | length }}</dd>
+            </div>
+            <div>
+                <dt>Credentials</dt>
+                <dd><code>{{ session.username }}:{{ session.password or '***' }}</code></dd>
+            </div>
+        </dl>
+    </div>
+
+    <div class="player-controls">
+        <div class="speed-control">
+            <label for="speed">Playback Speed:</label>
+            <select id="speed" onchange="updateSpeed(this.value)">
+                <option value="0.5">0.5x</option>
+                <option value="1" selected>1x</option>
+                <option value="2">2x</option>
+                <option value="5">5x</option>
+                <option value="10">10x</option>
+            </select>
+        </div>
+        <button class="btn" onclick="player.play()">Play</button>
+        <button class="btn" onclick="player.pause()">Pause</button>
+        <button class="btn" onclick="player.seek(0)">Restart</button>
+    </div>
+
+    <div class="player-wrapper">
+        <div id="player"></div>
+    </div>
+
+    <div class="playback-note">
+        <p><strong>Note:</strong> This is a recording of the attacker's SSH session.
+        Commands shown were executed within the honeypot sandbox.</p>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/asciinema-player@3.6.3/dist/bundle/asciinema-player.min.js"></script>
+<script>
+    var player = AsciinemaPlayer.create(
+        '{{ url_for("session_asciicast", session_id=session.id) }}',
+        document.getElementById('player'),
+        {
+            cols: 120,
+            rows: 30,
+            autoPlay: false,
+            loop: false,
+            speed: 1,
+            idleTimeLimit: 2,
+            theme: 'monokai',
+            fit: 'width',
+            controls: true,
+            pauseOnMarkers: false,
+            terminalFontFamily: "'Fira Code', 'Consolas', 'Monaco', monospace",
+        }
+    );
+
+    function updateSpeed(speed) {
+        player.setSpeed(parseFloat(speed));
+    }
+</script>
+{% endblock %}

--- a/web/templates/session_detail.html
+++ b/web/templates/session_detail.html
@@ -1,0 +1,134 @@
+{% extends "base.html" %}
+
+{% block title %}Session {{ session.id | truncate_hash }} - Cowrie Honeypot{% endblock %}
+
+{% block content %}
+<div class="session-detail">
+    <div class="page-header">
+        <h1>Session Details</h1>
+        <div class="header-actions">
+            {% if has_tty %}
+            <a href="{{ url_for('session_playback', session_id=session.id) }}" class="btn btn-primary">
+                Play Session Recording
+            </a>
+            {% endif %}
+            <a href="{{ url_for('sessions') }}" class="btn">Back to Sessions</a>
+        </div>
+    </div>
+
+    <!-- Session Info -->
+    <div class="detail-grid">
+        <div class="detail-card">
+            <h2>Connection Info</h2>
+            <dl class="detail-list">
+                <dt>Session ID</dt>
+                <dd><code>{{ session.id }}</code></dd>
+
+                <dt>Source IP</dt>
+                <dd>
+                    <a href="{{ url_for('sessions', ip=session.src_ip) }}">{{ session.src_ip }}</a>
+                </dd>
+
+                <dt>Location</dt>
+                <dd>
+                    {% if session.geo %}
+                    {{ session.geo.city }}, {{ session.geo.country }} ({{ session.geo.country_code }})
+                    {% else %}
+                    Unknown
+                    {% endif %}
+                </dd>
+
+                <dt>Client Version</dt>
+                <dd><code>{{ session.client_version or 'Unknown' }}</code></dd>
+
+                <dt>Start Time</dt>
+                <dd>{{ session.start_time | format_timestamp }}</dd>
+
+                <dt>End Time</dt>
+                <dd>{{ session.end_time | format_timestamp }}</dd>
+
+                <dt>Duration</dt>
+                <dd>{{ session.duration | format_duration }}</dd>
+            </dl>
+        </div>
+
+        <div class="detail-card">
+            <h2>Authentication</h2>
+            <dl class="detail-list">
+                <dt>Login Status</dt>
+                <dd>
+                    {% if session.login_success %}
+                    <span class="badge badge-success">Successful</span>
+                    {% else %}
+                    <span class="badge badge-danger">Failed</span>
+                    {% endif %}
+                </dd>
+
+                <dt>Username</dt>
+                <dd><code>{{ session.username or 'N/A' }}</code></dd>
+
+                <dt>Password</dt>
+                <dd><code>{{ session.password or 'N/A' }}</code></dd>
+            </dl>
+
+            {% if has_tty %}
+            <div class="tty-info">
+                <h3>TTY Recording Available</h3>
+                <p>This session has a terminal recording.</p>
+                <a href="{{ url_for('session_playback', session_id=session.id) }}" class="btn btn-primary">
+                    Watch Recording
+                </a>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Commands -->
+    <div class="detail-card full-width">
+        <h2>Commands Executed ({{ session.commands | length }})</h2>
+        {% if session.commands %}
+        <div class="command-list">
+            {% for cmd in session.commands %}
+            <div class="command-entry">
+                <span class="command-time">{{ cmd.timestamp | format_timestamp }}</span>
+                <code class="command-text">{{ cmd.command }}</code>
+            </div>
+            {% endfor %}
+        </div>
+        {% else %}
+        <p class="no-data">No commands recorded for this session</p>
+        {% endif %}
+    </div>
+
+    <!-- Downloads -->
+    {% if session.downloads %}
+    <div class="detail-card full-width">
+        <h2>Downloaded Files ({{ session.downloads | length }})</h2>
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Time</th>
+                    <th>URL</th>
+                    <th>SHA256</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for dl in session.downloads %}
+                <tr>
+                    <td>{{ dl.timestamp | format_timestamp }}</td>
+                    <td><code class="url-text">{{ dl.url }}</code></td>
+                    <td>
+                        <code>{{ dl.shasum | truncate_hash(24) }}</code>
+                        <a href="https://www.virustotal.com/gui/file/{{ dl.shasum }}"
+                           target="_blank"
+                           class="external-link"
+                           title="View on VirusTotal">VT</a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/web/templates/sessions.html
+++ b/web/templates/sessions.html
@@ -1,0 +1,111 @@
+{% extends "base.html" %}
+
+{% block title %}Sessions - Cowrie Honeypot{% endblock %}
+
+{% block content %}
+<div class="sessions-page">
+    <div class="page-header">
+        <h1>SSH Sessions</h1>
+        <div class="filters">
+            <form method="get" class="filter-form">
+                <select name="hours" onchange="this.form.submit()">
+                    <option value="24" {% if hours == 24 %}selected{% endif %}>Last 24 hours</option>
+                    <option value="48" {% if hours == 48 %}selected{% endif %}>Last 48 hours</option>
+                    <option value="168" {% if hours == 168 %}selected{% endif %}>Last 7 days</option>
+                    <option value="720" {% if hours == 720 %}selected{% endif %}>Last 30 days</option>
+                </select>
+                <input type="text" name="ip" placeholder="Filter by IP" value="{{ ip_filter }}">
+                <label>
+                    <input type="checkbox" name="has_commands" value="1"
+                           {% if has_commands == '1' %}checked{% endif %}
+                           onchange="this.form.submit()">
+                    Has commands
+                </label>
+                <label>
+                    <input type="checkbox" name="has_tty" value="1"
+                           {% if has_tty == '1' %}checked{% endif %}
+                           onchange="this.form.submit()">
+                    Has TTY recording
+                </label>
+                <button type="submit">Filter</button>
+            </form>
+        </div>
+    </div>
+
+    <div class="results-info">
+        Showing {{ sessions | length }} of {{ total }} sessions
+    </div>
+
+    <table class="data-table sessions-table">
+        <thead>
+            <tr>
+                <th>Session ID</th>
+                <th>IP Address</th>
+                <th>Country</th>
+                <th>Start Time</th>
+                <th>Duration</th>
+                <th>Credentials</th>
+                <th>Commands</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for session in sessions %}
+            <tr class="{% if session.login_success %}success-login{% endif %}">
+                <td>
+                    <a href="{{ url_for('session_detail', session_id=session.id) }}">
+                        {{ session.id | truncate_hash }}
+                    </a>
+                </td>
+                <td>
+                    <a href="?ip={{ session.src_ip }}&hours={{ hours }}">{{ session.src_ip }}</a>
+                </td>
+                <td>{{ session.geo.country if session.geo else 'Unknown' }}</td>
+                <td>{{ session.start_time | format_timestamp }}</td>
+                <td>{{ session.duration | format_duration }}</td>
+                <td>
+                    {% if session.username %}
+                    <code>{{ session.username }}:{{ session.password or '***' }}</code>
+                    {% else %}
+                    <span class="no-data">N/A</span>
+                    {% endif %}
+                </td>
+                <td>
+                    {{ session.commands | length }}
+                    {% if session.downloads %}
+                    <span class="badge badge-warning" title="Downloaded {{ session.downloads | length }} file(s)">
+                        {{ session.downloads | length }}
+                    </span>
+                    {% endif %}
+                </td>
+                <td class="actions">
+                    <a href="{{ url_for('session_detail', session_id=session.id) }}" class="btn btn-sm">View</a>
+                    {% if session.tty_log %}
+                    <a href="{{ url_for('session_playback', session_id=session.id) }}" class="btn btn-sm btn-primary">Play</a>
+                    {% endif %}
+                </td>
+            </tr>
+            {% else %}
+            <tr>
+                <td colspan="8" class="no-data">No sessions found</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    <!-- Pagination -->
+    {% if total > per_page %}
+    <div class="pagination">
+        {% if page > 1 %}
+        <a href="?page={{ page - 1 }}&hours={{ hours }}&ip={{ ip_filter }}&has_commands={{ has_commands }}&has_tty={{ has_tty }}" class="btn">&laquo; Previous</a>
+        {% endif %}
+
+        <span class="page-info">Page {{ page }} of {{ (total // per_page) + (1 if total % per_page else 0) }}</span>
+
+        {% if page * per_page < total %}
+        <a href="?page={{ page + 1 }}&hours={{ hours }}&ip={{ ip_filter }}&has_commands={{ has_commands }}&has_tty={{ has_tty }}" class="btn">Next &raquo;</a>
+        {% endif %}
+    </div>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
- Create Flask-based web service for viewing and replaying honeypot sessions
- Add TTY recording support via Cowrie's output_playlog
- Implement session listing, detail views, and asciinema-based playback
- Include dashboard with attack statistics, top countries, and commands
- Add downloads viewer with VirusTotal links
- Deploy as Docker container alongside Cowrie (cowrie-web)
- Access via SSH tunnel only (localhost:5000) for security
- Optional Tailscale integration for remote access
- Update daily reports to include session links when configured
- Add [web_dashboard] section to example-config.toml