### PR TITLE
Improve Postfix configuration for better email delivery

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -44,6 +44,16 @@ email_subject_prefix = "[Honeypot]"
 [email]
 # Scaleway Transactional Email settings
 # Docs: https://www.scaleway.com/en/docs/managed-services/transactional-email/
+
+# Your verified domain in Scaleway Transactional Email
+# This domain is used for:
+# - myorigin (default domain for outbound mail)
+# - mydestination (domains this server receives mail for)
+# - masquerade_domains (rewrite sender addresses to use this domain)
+# - Appended to myhostname for the full FQDN
+# Example: "example.com" or "mail.example.com"
+scaleway_domain = "yourdomain.com"
+
 smtp_host = "smtp.tem.scw.cloud"
 smtp_port = 587
 smtp_user = "YOUR_SMTP_USERNAME"


### PR DESCRIPTION
## Summary

Enhances the Postfix configuration with proper domain settings and security hardening to improve email deliverability and prevent common misconfigurations.

## Changes

### Domain Configuration
- **Added `scaleway_domain` field** to `[email]` section in `example-config.toml`
- **Set `myorigin`** to use the Scaleway verified domain (default domain for outbound mail)
- **Updated `mydestination`** to include both localhost and the configured domain
- **Configured `masquerade_domains`** to rewrite sender addresses with the proper domain
- **Updated `myhostname`** to use FQDN format: `<hostname>.<domain>`

### Security Hardening
- **`mynetworks`** - Restricted to loopback only: `127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128`
- **`inet_interfaces`** - Set to `loopback-only` to prevent accepting external connections
- **`inet_protocols`** - Set to `all` to support both IPv4 and IPv6
- **`local_header_rewrite_clients`** - Set to `static:all` for proper header rewriting
- **`append_at_myorigin`** - Enabled to automatically append @domain to local addresses

## Benefits

✅ **Better email deliverability** - Proper domain configuration improves SPF/DKIM alignment  
✅ **Enhanced security** - Loopback-only configuration prevents open relay  
✅ **Cleaner sender addresses** - Masquerading ensures consistent domain in outbound emails  
✅ **Professional appearance** - Proper FQDN and domain settings look more legitimate  

## Configuration Example

```toml
[email]
scaleway_domain = "example.com"
smtp_host = "smtp.tem.scw.cloud"
smtp_port = 587
smtp_user = "YOUR_SMTP_USERNAME"
smtp_password = "YOUR_SMTP_PASSWORD"
```

This will configure Postfix with:
- `myhostname = cowrie-honeypot-abc123.example.com`
- `myorigin = example.com`
- `mydestination = localhost, example.com`
- `masquerade_domains = example.com`

## Testing

The changes maintain backward compatibility with a fallback to `localhost` if `scaleway_domain` is not configured.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)