### PR TITLE
fix: Enable file type display and preview in web dashboard

### DIFF
--- a/deploy_cowrie_honeypot.sh
+++ b/deploy_cowrie_honeypot.sh
@@ -897,11 +897,13 @@ services:
     volumes:
       - cowrie-var:/cowrie-data:ro
       - /var/lib/GeoIP:/geoip:ro
+      - /opt/cowrie/var:/yara-cache:ro
     environment:
       - COWRIE_LOG_PATH=/cowrie-data/log/cowrie/cowrie.json
       - COWRIE_TTY_PATH=/cowrie-data/lib/cowrie/tty
       - COWRIE_DOWNLOAD_PATH=/cowrie-data/lib/cowrie/downloads
       - GEOIP_DB_PATH=/geoip/GeoLite2-City.mmdb
+      - YARA_CACHE_DB_PATH=/yara-cache/yara-cache.db
       - BASE_URL=$WEB_BASE_URL
       - VIRUSTOTAL_API_KEY=$VT_API_KEY
     depends_on:

--- a/scripts/yara-scanner-daemon.py
+++ b/scripts/yara-scanner-daemon.py
@@ -64,6 +64,7 @@ class FileAnalysisCache:
         "text/xml",
         "text/css",
         "text/javascript",
+        "text/x-ssh-public-key",
         "application/json",
         "application/xml",
         "application/x-sh",

--- a/web/docker-compose.web.yml
+++ b/web/docker-compose.web.yml
@@ -51,15 +51,15 @@ services:
       # Mount Cowrie data read-only
       - cowrie-var:/cowrie-data:ro
       # Mount GeoIP database if available
-      - /opt/cowrie/geoip:/cowrie-data/geoip:ro
+      - /var/lib/GeoIP:/geoip:ro
       # Mount YARA/VT cache directory (from yara-scanner-daemon on host)
-      - /opt/cowrie/var:/cowrie-data/var:ro
+      - /opt/cowrie/var:/yara-cache:ro
     environment:
       - COWRIE_LOG_PATH=/cowrie-data/log/cowrie/cowrie.json
       - COWRIE_TTY_PATH=/cowrie-data/lib/cowrie/tty
       - COWRIE_DOWNLOAD_PATH=/cowrie-data/lib/cowrie/downloads
-      - GEOIP_DB_PATH=/cowrie-data/geoip/GeoLite2-City.mmdb
-      - YARA_CACHE_DB_PATH=/cowrie-data/var/yara-cache.db
+      - GEOIP_DB_PATH=/geoip/GeoLite2-City.mmdb
+      - YARA_CACHE_DB_PATH=/yara-cache/yara-cache.db
       - BASE_URL=${WEB_BASE_URL:-}
     depends_on:
       - cowrie


### PR DESCRIPTION
## Summary

Fixes web dashboard not displaying file type information or preview buttons for downloaded files by enabling YARA cache database access in the web container.

## Changes

- **deploy_cowrie_honeypot.sh**: Add YARA cache volume mount and environment variable to generated docker-compose.yml
- **web/docker-compose.web.yml**: Update template with correct YARA cache configuration  
- **scripts/yara-scanner-daemon.py**: Add `text/x-ssh-public-key` to PREVIEWABLE_MIMES for SSH key previews

## Technical Details

The web container was missing:
1. Volume mount: `/opt/cowrie/var:/yara-cache:ro`
2. Environment variable: `YARA_CACHE_DB_PATH=/yara-cache/yara-cache.db`

This prevented the web app from accessing the YARA cache database containing file type information, categories, and previewability flags.

## Testing

✅ Type column displays file categories (data, script, executable, etc.)  
✅ Preview buttons appear for text-based files  
✅ SSH public keys are now previewable  
✅ File type information is correctly retrieved from YARA cache database

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)