### PR TITLE
docs: Move nginx configuration from CLAUDE.md to README.md

### DIFF
--- a/example-config.toml
+++ b/example-config.toml
@@ -119,7 +119,7 @@ enabled = false
 # The honeypot runs on Tailscale (private network), but Canary webhooks need a
 # public endpoint. Set up nginx on your existing server to proxy to Tailscale.
 #
-# See CLAUDE.md for nginx configuration example.
+# See README.md "Canary Token Webhook Receiver" section for nginx configuration.
 
 # Enable webhook receiver (default: false)
 enabled = false

--- a/web/templates/canary_alerts.html
+++ b/web/templates/canary_alerts.html
@@ -123,7 +123,7 @@
             <strong>Public URL (via nginx reverse proxy):</strong><br>
             <code>https://&lt;your-server&gt;/webhook/canary</code>
             <p style="font-size: 0.85em; color: #666; margin-top: 5px;">
-                Set up nginx on your existing server to proxy webhooks to the honeypot via Tailscale. See CLAUDE.md for configuration.
+                Set up nginx on your existing server to proxy webhooks to the honeypot via Tailscale. See README.md for configuration.
             </p>
         </div>
 


### PR DESCRIPTION
Move the Canary Token webhook nginx reverse proxy configuration from CLAUDE.md to README.md for better visibility and easier access for users.

Changes:
- Add 'Canary Token Webhook Receiver' section to README.md with:
  - What are Canary Tokens explanation
  - Setup steps
  - Complete nginx reverse proxy configuration
  - Security features summary
- Update example-config.toml to reference README.md instead of CLAUDE.md
- Update web/templates/canary_alerts.html to reference README.md
- Simplify CLAUDE.md to only reference README.md for nginx setup
- Remove duplicate nginx configuration from CLAUDE.md

This makes the setup instructions more accessible in the main README while keeping CLAUDE.md focused on detailed project architecture and advanced features.