### PR TITLE
Fix linter errors in GitHub Actions workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ cp example-config.toml master-config.toml
 - **Security**: Honeypot runs on modern Debian (e.g., debian-13)
 - **Flexibility**: Test filesystem compatibility across versions
 
-### Configuration
+### OS Version Configuration
 
 ```toml
 [deployment]
@@ -115,7 +115,7 @@ deployment_image = "debian-13"   # What actually runs
 server_image = "debian-13"
 ```
 
-### How It Works
+### OS Version Compatibility
 
 **Generation:** Creates `source_metadata.json` with OS version info
 **Deployment:** Validates compatibility, warns if gap >2 major versions
@@ -129,7 +129,7 @@ server_image = "debian-13"
 
 **FastAPI service for remote access to Cowrie data.**
 
-### Features
+### API Features
 
 - RESTful API with sessions, downloads, stats endpoints
 - Read-only access (security hardened)
@@ -137,7 +137,7 @@ server_image = "debian-13"
 - TTY recording retrieval
 - Runs with dropped capabilities and read-only filesystem
 
-### Configuration
+### API Configuration
 
 **Single-Host Mode** (internal use):
 ```toml
@@ -157,7 +157,7 @@ tailscale_api_hostname = "cowrie-api"
 ### Key Endpoints
 
 | Endpoint | Description |
-|----------|-------------|
+| -------- | ----------- |
 | `GET /api/v1/health` | Health check |
 | `GET /api/v1/sessions` | List sessions (filters/pagination) |
 | `GET /api/v1/sessions/{id}` | Session detail |
@@ -260,7 +260,7 @@ dashboard_sources = ["cowrie-hp-1", "cowrie-hp-2"]
 
 **Tailscale is now REQUIRED for all deployments.**
 
-### Configuration
+### Tailscale Configuration
 
 ```toml
 [tailscale]
@@ -295,7 +295,7 @@ https://cowrie-honeypot.tail9e5e41.ts.net
 
 **Flask-based dashboard with session playback and live attack map.**
 
-### Features
+### Dashboard Features
 
 - 📊 Dashboard with attack statistics
 - 🗺️ Live attack map with geographic visualization
@@ -307,7 +307,7 @@ https://cowrie-honeypot.tail9e5e41.ts.net
 - 🔗 Email report session links
 - 🔒 Tailscale/SSH tunnel only (not public)
 
-### Configuration
+### Dashboard Configuration
 
 ```toml
 [web_dashboard]
@@ -321,7 +321,7 @@ Access via: `https://<tailscale_name>.<tailscale_domain>`
 
 **IPs locked to first successful credentials** (prevents honeypot fingerprinting).
 
-### How It Works
+### IP-Lock Mechanism
 
 ```text
 1. IP 1.2.3.4: root:password → Success ✓ (IP locked)
@@ -375,7 +375,7 @@ enabled = true
 
 **Automated email reports with threat intelligence.**
 
-### Configuration
+### Reporting Configuration
 
 ```toml
 [honeypot]
@@ -417,7 +417,7 @@ uv run scripts/daily-report.py --test
 
 **Background daemon scans downloaded malware automatically.**
 
-### Features
+### YARA Features
 
 - Inotify monitoring of downloads directory
 - YARA Forge full ruleset (~1000+ rules)

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ cp master-config-dashboard.toml master-config.toml
 
 **7. Access centralized dashboard**
 
-```
+```text
 https://cowrie-dashboard.tail9e5e41.ts.net
 ```
 
@@ -230,7 +230,7 @@ chmod +x deploy-multi.sh
 
 **Recommended structure:**
 
-```
+```text
 cowrie-deploy-toolkit/
 ├── master-config-hp1.toml       # Honeypot 1 config
 ├── master-config-hp2.toml       # Honeypot 2 config

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.12-slim
 WORKDIR /app
 
 # Install system dependencies
+# hadolint ignore=DL3008
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libmaxminddb0 \
     libmaxminddb-dev \

--- a/deploy_cowrie_honeypot.sh
+++ b/deploy_cowrie_honeypot.sh
@@ -109,7 +109,8 @@ find_latest_output() {
 
     # Find all matching directories, sorted by timestamp (newest first)
     # Pattern: output_<honeypot-name>_YYYYMMDD_HHMMSS
-    local latest=$(find . -maxdepth 1 -type d -name "output_${honeypot_name}_*" | sort -r | head -n1)
+    local latest
+    latest=$(find . -maxdepth 1 -type d -name "output_${honeypot_name}_*" | sort -r | head -n1)
 
     if [ -z "$latest" ]; then
         return 1
@@ -154,8 +155,7 @@ if [ "$DEPLOY_ALL" = true ]; then
     MISSING_OUTPUTS=()
 
     for name in "${HONEYPOT_NAMES[@]}"; do
-        latest_output=$(find_latest_output "$name")
-        if [ $? -eq 0 ]; then
+        if latest_output=$(find_latest_output "$name"); then
             HONEYPOT_OUTPUTS["$name"]="$latest_output"
             echo_info "  $name: $latest_output"
         else
@@ -234,8 +234,6 @@ fi
 # Default deployment configuration
 SERVER_TYPE="cpx11"
 SERVER_IMAGE="debian-13"
-SSH_KEY_NAME1="SSH Key 1"
-SSH_KEY_NAME2="SSH Key 2"
 COWRIE_SSH_PORT="22"        # Cowrie listens on port 22
 REAL_SSH_PORT="2222"        # Move real SSH to 2222
 
@@ -1744,6 +1742,7 @@ if [ "$ENABLE_API" = "true" ]; then
 
     # Deploy API container
     echo_info "Building and starting Cowrie API container..."
+    # shellcheck disable=SC2087
     ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -p "$REAL_SSH_PORT" "root@$SERVER_IP" bash << APIEOF
 set -e
 cd /opt/cowrie

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -374,10 +374,8 @@ cleanup_tailscale_device() {
 
     # List all devices in the tailnet
     local devices_json
-    devices_json=$(curl -s -H "Authorization: Bearer $api_key" \
-        "https://api.tailscale.com/api/v2/tailnet/$tailnet/devices" 2>/dev/null)
-
-    if [ $? -ne 0 ] || [ -z "$devices_json" ]; then
+    if ! devices_json=$(curl -s -H "Authorization: Bearer $api_key" \
+        "https://api.tailscale.com/api/v2/tailnet/$tailnet/devices" 2>/dev/null) || [ -z "$devices_json" ]; then
         echo_warn "Failed to fetch devices from Tailscale API"
         return 1
     fi
@@ -402,11 +400,8 @@ cleanup_tailscale_device() {
 
             echo_info "Deleting device: $device_name (ID: $device_id)"
 
-            local delete_result
-            delete_result=$(curl -s -X DELETE -H "Authorization: Bearer $api_key" \
-                "https://api.tailscale.com/api/v2/device/$device_id" 2>/dev/null)
-
-            if [ $? -eq 0 ]; then
+            if curl -s -X DELETE -H "Authorization: Bearer $api_key" \
+                "https://api.tailscale.com/api/v2/device/$device_id" >/dev/null 2>&1; then
                 echo_info "Successfully deleted device: $device_name"
                 ((count++))
             else


### PR DESCRIPTION
Fixes multiple linting errors reported by super-linter in the GitHub Actions workflow.

## Changes

### BASH (shellcheck)
- **SC2155**: Separated declaration and assignment in `deploy_cowrie_honeypot.sh:112` to avoid masking return values
- **SC2181**: Changed to check exit codes directly instead of using `$?` in multiple locations
- **SC2034**: Removed unused variables `SSH_KEY_NAME1` and `SSH_KEY_NAME2`
- **SC2087**: Added shellcheck disable comment for intentional client-side variable expansion in heredoc

### Dockerfile
- **DL3008**: Added hadolint ignore comment for system package installations (appropriate for Debian packages)

### Markdown
- **MD024**: Fixed duplicate headings by making them context-specific:
  - "Configuration" → "OS Version Configuration", "API Configuration", etc.
  - "Features" → "API Features", "Dashboard Features", "YARA Features"
  - "How It Works" → "OS Version Compatibility", "IP-Lock Mechanism"
- **MD060**: Fixed table column spacing in CLAUDE.md
- **MD040**: Added `text` language specifier to code blocks in README.md

### Python
- Already fixed in previous commit (1f46cae)

## Testing
- Verified locally with `shellcheck` - no errors reported
- All changes maintain existing functionality
- Linter fixes only, no behavior changes

Closes #79