### PR TITLE
Fix remaining linter errors in CI

### DIFF
--- a/api/routes/downloads.py
+++ b/api/routes/downloads.py
@@ -4,6 +4,7 @@ Downloads endpoints
 Provides access to downloaded files (malware samples)
 """
 
+from datetime import datetime
 from pathlib import Path
 
 from config import config
@@ -79,6 +80,3 @@ async def download_file(sha256: str):
 
     return FileResponse(filepath, media_type="application/octet-stream", filename=sha256)
 
-
-# Import datetime for file timestamps
-from datetime import datetime

--- a/deploy_cowrie_honeypot.sh
+++ b/deploy_cowrie_honeypot.sh
@@ -492,12 +492,6 @@ if [ "$GREYNOISE_ENABLED" = "true" ]; then
     echo_info "GreyNoise threat intelligence enabled"
 fi
 
-# Canary webhook configuration
-CANARY_WEBHOOK_ENABLED=$(get_config "canary_webhook_enabled" "false")
-
-# Advanced configuration
-REPORT_HOURS=$(get_config "report_hours" "24")
-
 echo_info "Configuration loaded successfully"
 
 SERVER_NAME="cowrie-honeypot-$(date +%s)"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -490,6 +490,7 @@ get_honeypot_count() {
 # Example: get_honeypot_names "config.toml" HONEYPOT_NAMES
 get_honeypot_names() {
     local toml_file="$1"
+    # shellcheck disable=SC2178
     local -n array_ref="$2"  # nameref to the array variable
     local script_dir
     script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
## Summary
- Fixed all remaining linter errors reported in CI run #20568647525
- Removed unused variables in bash scripts
- Added shellcheck directive for valid nameref usage
- Moved Python import to correct location

## Changes

### BASH Fixes
- **deploy_cowrie_honeypot.sh:496** - Removed unused `CANARY_WEBHOOK_ENABLED` variable
- **deploy_cowrie_honeypot.sh:499** - Removed unused `REPORT_HOURS` variable  
- **scripts/common.sh:493** - Added `shellcheck disable=SC2178` for nameref (this is valid bash syntax)

### Python Fixes
- **api/routes/downloads.py** - Moved `datetime` import from line 84 to top of file with other imports (PEP 8 compliance)

## Testing
All linter errors have been addressed. CI should pass cleanly now.

## Reference
- Closes #81
- Original failing CI: https://github.com/reuteras/cowrie-deploy-toolkit/actions/runs/20568647525/job/59071326678

🤖 Generated with [Claude Code](https://claude.com/claude-code)