### PR TITLE
fix: Expose API port to host when using Tailscale Serve

### DIFF
--- a/deploy_cowrie_honeypot.sh
+++ b/deploy_cowrie_honeypot.sh
@@ -1729,6 +1729,14 @@ if [ "$ENABLE_API" = "true" ]; then
 set -e
 cd /opt/cowrie
 
+# Expose API port to host if using Tailscale Serve
+if [ "$API_EXPOSE_VIA_TAILSCALE" = "true" ]; then
+    echo "[remote] Exposing API port 8000 to host for Tailscale Serve..."
+    # Uncomment the ports section in docker-compose.api.yml
+    sed -i 's/# ports:/ports:/' docker-compose.api.yml
+    sed -i 's/#   - "127.0.0.1:8000:8000"/  - "127.0.0.1:8000:8000"/' docker-compose.api.yml
+fi
+
 # Build and start API with the main compose file
 echo "[remote] Building Cowrie API container (this may take a minute)..."
 if ! docker compose -f docker-compose.yml -f docker-compose.api.yml build --quiet cowrie-api 2>&1 | grep -E "ERROR|WARN" || true; then


### PR DESCRIPTION
## Problem

After PR #87 fixed the Tailscale Serve configuration, the API still returns **502 Bad Gateway**:

```
cowrie-web | [!] Error fetching stats from API: 502 Server Error: Bad Gateway for url: 
https://chp-2.tail9e5e41.ts.net/api/v1/stats/overview?hours=24
```

## Root Cause

The API container port is **not exposed to the host**:

```bash
# Current state
docker ps
cowrie-api   ... 8000/tcp  # ❌ No port mapping to host
```

This means:
1. ✅ Tailscale Serve is configured and listening on port 443
2. ✅ Tailscale Serve tries to proxy to `localhost:8000`
3. ❌ But the API container's port 8000 is not accessible on the host
4. Result: **502 Bad Gateway**

## Why This Happens

In `docker-compose.api.yml`, the ports section is commented out by default for security:

```yaml
# Internal network only by default
# For multi-host deployment, expose via Tailscale Serve
# ports:
#   - "127.0.0.1:8000:8000"  # Uncomment for local testing
```

This is correct for API-only internal use, but when `api_expose_via_tailscale = true`, we need the port exposed to the host so Tailscale Serve can reach it.

## Solution

This PR automatically uncomments the ports section when Tailscale Serve is enabled:

```bash
if [ "$API_EXPOSE_VIA_TAILSCALE" = "true" ]; then
    echo "[remote] Exposing API port 8000 to host for Tailscale Serve..."
    sed -i 's/# ports:/ports:/' docker-compose.api.yml
    sed -i 's/#   - "127.0.0.1:8000:8000"/  - "127.0.0.1:8000:8000"/' docker-compose.api.yml
fi
```

## Changes

### Modified: `deploy_cowrie_honeypot.sh`

Added port exposure logic before building API container (lines 1732-1738):
- Detects if `api_expose_via_tailscale = true`
- Uncomments port mapping in `docker-compose.api.yml`
- Binds to `127.0.0.1:8000` only (localhost for security)
- Runs before container build/start

## Security

The port is bound to **127.0.0.1 only** (not 0.0.0.0):
- ✅ Only accessible from the host machine
- ✅ Not exposed to external network
- ✅ Tailscale Serve provides HTTPS and authentication
- ✅ Maintains security while enabling functionality

## Expected Result

After this fix:

```bash
docker ps
cowrie-api   ... 127.0.0.1:8000->8000/tcp  # ✅ Port accessible on host
```

Flow:
```
Dashboard → HTTPS (Tailscale) → chp-2.tailnet:443 → 
Tailscale Serve → localhost:8000 → API Container ✅
```

## Testing

- ✅ Bash syntax validation
- ✅ Shellcheck passed
- ✅ Sed patterns tested for correct YAML modification

## Related

- Closes #88
- Builds on #87 (Tailscale Serve configuration)

Together, these two PRs complete the multi-honeypot API access feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)