### PR TITLE
fix: Expose API port to host when using Tailscale Serve

### DIFF
--- a/deploy_cowrie_honeypot.sh
+++ b/deploy_cowrie_honeypot.sh
@@ -1747,6 +1747,14 @@ if [ "$ENABLE_API" = "true" ]; then
 set -e
 cd /opt/cowrie
 
+# Expose API port to host if using Tailscale Serve
+if [ "$API_EXPOSE_VIA_TAILSCALE" = "true" ]; then
+    echo "[remote] Exposing API port 8000 to host for Tailscale Serve..."
+    # Uncomment the ports section in docker-compose.api.yml
+    sed -i 's/# ports:/ports:/' docker-compose.api.yml
+    sed -i 's/#   - "127.0.0.1:8000:8000"/  - "127.0.0.1:8000:8000"/' docker-compose.api.yml
+fi
+
 # Build and start API with the main compose file
 echo "[remote] Building Cowrie API container..."
 if ! docker compose -f docker-compose.yml -f docker-compose.api.yml build cowrie-api 2>&1; then


### PR DESCRIPTION
When api_expose_via_tailscale is enabled, the API container port must be exposed to the host so Tailscale Serve can proxy requests to it.

The docker-compose.api.yml file has the ports section commented out by default for security (internal network only). This change automatically uncomments the port mapping when Tailscale exposure is enabled.

Changes:
- Add sed commands to uncomment ports section in docker-compose.api.yml
- Only expose 127.0.0.1:8000 (localhost binding for security)
- Runs before building/starting containers

This fixes the 502 Bad Gateway error where Tailscale Serve was configured but couldn't reach the backend API service.

Related to #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)