### PR TITLE
fix: Use consistent check for API cron job path routing

### DIFF
--- a/deploy_cowrie_honeypot.sh
+++ b/deploy_cowrie_honeypot.sh
@@ -1782,11 +1782,11 @@ if [ "$API_EXPOSE_VIA_TAILSCALE" = "true" ] && command -v tailscale &> /dev/null
 
     # Add @reboot cron job to ensure Tailscale Serve persists after reboot
     (crontab -l 2>/dev/null || echo "") | grep -v "tailscale serve.*8000" | crontab -
-    if tailscale serve status 2>/dev/null | grep -q "/api"; then
-        # Path-based routing
+    if tailscale serve status 2>/dev/null | grep -q ":443"; then
+        # Path-based routing (port 443 already in use by dashboard)
         (crontab -l; echo "@reboot sleep 30 && /usr/bin/tailscale serve --https=443 --set-path=/api --bg localhost:8000 > /dev/null 2>&1") | crontab -
     else
-        # Direct port mapping
+        # Direct port mapping (API only, no dashboard)
         (crontab -l; echo "@reboot sleep 30 && /usr/bin/tailscale serve --https=443 --bg localhost:8000 > /dev/null 2>&1") | crontab -
     fi
 


### PR DESCRIPTION
## Summary

Fixes inconsistent conditional check when creating the API Tailscale Serve cron job, which could result in the wrong cron job being created even when path-based routing is needed.

## Problem

After PR #94 fixed the Tailscale Serve syntax, there's still an issue with the cron job creation logic:

- Initial setup at line 1774: Checks `if tailscale serve status | grep -q ":443"`
- Cron job creation at line 1785: Checks `if tailscale serve status | grep -q "/api"`

The cron job check for `/api` in the status could fail even when path-based routing was used, resulting in a cron job without `--set-path=/api`, which would overwrite the dashboard on reboot.

## Solution

Changed line 1785 to use the same check as line 1774: `grep -q ":443"` instead of `grep -q "/api"`.

This ensures consistent behavior:
- If port 443 is in use → use path-based routing (both for initial setup AND cron job)
- If port 443 is not in use → use direct port mapping (both for initial setup AND cron job)

## Impact

Without this fix, even with correct initial Tailscale Serve setup, the cron job created might use the wrong syntax, causing the API to overwrite the dashboard's root path after a reboot.

Related to #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)