### PR TITLE
fix: Use timezone-aware datetimes in API stats endpoint

### DIFF
--- a/api/routes/stats.py
+++ b/api/routes/stats.py
@@ -5,7 +5,7 @@ Provides aggregated statistics from Cowrie data
 """
 
 from collections import Counter
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Query
 from services.log_parser import parser
@@ -32,7 +32,7 @@ async def get_stats_overview(days: int = Query(7, ge=1, le=365)):
     all_sessions = parser.get_sessions(limit=10000)  # Get a large number
 
     # Filter by time range
-    cutoff = datetime.now() - timedelta(days=days)
+    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     recent_sessions = []
     for session in all_sessions:
         if session.get("start_time"):
@@ -71,7 +71,7 @@ async def get_stats_overview(days: int = Query(7, ge=1, le=365)):
     top_commands = [{"command": cmd, "count": count} for cmd, count in command_counter.most_common(10)]
 
     return {
-        "time_range": {"start": cutoff.isoformat(), "end": datetime.now().isoformat(), "days": days},
+        "time_range": {"start": cutoff.isoformat(), "end": datetime.now(timezone.utc).isoformat(), "days": days},
         "totals": {
             "sessions": total_sessions,
             "unique_ips": unique_ips,


### PR DESCRIPTION
## Summary

Fixes 500 Internal Server Error in `/api/v1/stats/overview` endpoint caused by comparing timezone-naive and timezone-aware datetime objects.

## Problem

The stats endpoint was crashing with:
```
ERROR - Unhandled exception: can't compare offset-naive and offset-aware datetimes
```

This occurred because:
1. Line 35: `cutoff = datetime.now() - timedelta(days=days)` creates timezone-**naive** datetime
2. Line 40: `dt = datetime.fromisoformat(session["start_time"].replace("Z", "+00:00"))` creates timezone-**aware** datetime (UTC from Cowrie logs)
3. Line 41: `if dt >= cutoff:` comparison fails - Python doesn't allow comparing naive and aware datetimes

## Solution

Changed all `datetime.now()` calls to `datetime.now(timezone.utc)` to make them timezone-aware:
- Line 35: Cutoff calculation for filtering sessions
- Line 74: Current time in response payload

This ensures all datetime objects are timezone-aware (UTC) and can be properly compared.

## Testing

After this fix:
- Stats endpoint should return 200 OK instead of 500 error
- Dashboard overview page should load successfully
- Time filtering should work correctly across all timezones

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)