### PR TITLE
fix: Sanitize container version output to prevent VERSION.json parsing errors

### DIFF
--- a/scripts/update-agent.sh
+++ b/scripts/update-agent.sh
@@ -344,14 +344,14 @@ update_version_file() {
     web_image_id=$(docker compose images cowrie-web --format json 2>/dev/null | jq -r '.[0].ID // "unknown"')
 
     local web_version
-    web_version=$(docker compose exec -T cowrie-web python -c "import sys; sys.path.insert(0, '/app'); from app import __version__; print(__version__)" 2>/dev/null || echo "unknown")
+    web_version=$(docker compose exec -T cowrie-web python -c "import sys; sys.path.insert(0, '/app'); from app import __version__; print(__version__)" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | tr -d '\000-\037' | sed 's/[[:space:]]*$//' || echo "unknown")
 
     local api_image_id="N/A"
     local api_version="N/A"
 
     if [ -f "${COWRIE_DIR}/docker-compose.api.yml" ]; then
         api_image_id=$(docker compose -f docker-compose.yml -f docker-compose.api.yml images cowrie-api --format json 2>/dev/null | jq -r '.[0].ID // "unknown"')
-        api_version=$(docker compose -f docker-compose.yml -f docker-compose.api.yml exec -T cowrie-api python -c "import sys; sys.path.insert(0, '/app'); from app import __version__; print(__version__)" 2>/dev/null || echo "unknown")
+        api_version=$(docker compose -f docker-compose.yml -f docker-compose.api.yml exec -T cowrie-api python -c "import sys; sys.path.insert(0, '/app'); from app import __version__; print(__version__)" 2>/dev/null | sed 's/\x1b\[[0-9;]*m//g' | tr -d '\000-\037' | sed 's/[[:space:]]*$//' || echo "unknown")
     fi
 
     local tailscale_ip


### PR DESCRIPTION
## Summary

Fixes #98 - Sanitizes docker exec output to prevent VERSION.json parsing errors caused by ANSI escape codes and control characters.

## Problem

During deployment, VERSION.json creation failed with:
```
jq: parse error: Invalid string: control characters from U+0000 through U+001F must be escaped at line 27, column 6
```

The issue occurred when `docker compose exec` commands returned container version strings containing ANSI color codes and control characters, which were directly embedded into the JSON file, causing jq to fail.

## Solution

Added sanitization pipeline to version string retrieval:
1. `sed 's/\x1b\[[0-9;]*m//g'` - Remove ANSI escape sequences (color codes)
2. `tr -d '\000-\037'` - Remove control characters (U+0000 through U+001F)
3. `sed 's/[[:space:]]*$//'` - Trim trailing whitespace

Applied to both:
- `web_version` (line 347)
- `api_version` (line 354)

## Testing

Verified sanitization works correctly:
```bash
echo -e "2.1.0\x1b[0m\n" | sed 's/\x1b\[[0-9;]*m//g' | tr -d '\000-\037' | sed 's/[[:space:]]*$//'
# Output: 2.1.0 (clean)
```

## Impact

- Fixes deployment failures caused by invalid JSON
- Ensures VERSION.json can be parsed by jq
- No functional changes to version detection logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)