### PR TITLE
Fix downloads display and aggregation in multi-source dashboard

### DIFF
--- a/api/services/sqlite_parser.py
+++ b/api/services/sqlite_parser.py
@@ -229,6 +229,18 @@ class SQLiteStatsParser:
             )
             totals["unique_downloads"] = cursor.fetchone()["unique_downloads"]
 
+            # Get list of unique SHA256 hashes for deduplication across sources
+            cursor.execute(
+                """
+                SELECT DISTINCT shasum
+                FROM downloads
+                WHERE timestamp >= ? AND shasum IS NOT NULL
+                ORDER BY shasum
+                """,
+                (cutoff_str,),
+            )
+            totals["unique_download_hashes"] = [row["shasum"] for row in cursor.fetchall()]
+
             # Top IPs with GeoIP enrichment
             cursor.execute(
                 """

--- a/web/datasource.py
+++ b/web/datasource.py
@@ -291,6 +291,7 @@ class DataSource:
                 "sessions_with_commands": totals.get("sessions_with_commands", 0),
                 "total_downloads": totals.get("downloads", 0),
                 "unique_downloads": totals.get("unique_downloads", 0),
+                "unique_download_hashes": totals.get("unique_download_hashes", []),  # NEW: for proper deduplication
                 "ip_list": ip_list,
                 "ip_locations": api_data.get("ip_locations", []),  # Now enriched by API
                 "top_countries": api_data.get("top_countries", []),  # Now enriched by API


### PR DESCRIPTION
## Summary

Fixes the downloads page and download statistics in multi-source dashboard mode. Downloads now display correctly and counts are properly deduplicated across sources.

## Problem

- Downloads page showed no files in multi-source mode
- Stats showed incorrect counts (e.g., "2/4" when there were 18 total downloads)
- No proper deduplication of downloads across multiple honeypot sources

## Changes

**Multi-source downloads aggregation:**
- Added `MultiSourceDataSource.get_downloads()` method to aggregate downloads from all sources
- Deduplicates by SHA256 hash and tracks which sources have each file
- Queries via API endpoints that already have file metadata, YARA, and VirusTotal data

**Stats deduplication fix:**
- API stats endpoint now returns list of unique SHA256 hashes (`unique_download_hashes` field)
- Multi-source aggregation uses these hashes for proper cross-source deduplication
- Backward compatible with count-based fallback

**Dashboard route update:**
- `/downloads` route now uses proper `get_downloads()` method from datasource
- Handles both single-source and multi-source modes correctly
- No longer tries to check file existence locally for remote sources

## Files Changed

- `api/services/sqlite_parser.py`: Query for unique SHA256 list in stats
- `web/datasource.py`: Extract `unique_download_hashes` from API response
- `web/multisource.py`: New `get_downloads()` method + stats deduplication fix
- `web/app.py`: Updated `/downloads` route to use datasource abstraction

## Testing

- [x] Python syntax checks pass for all modified files
- [x] Backward compatible with single-source mode
- [x] Maintains legacy count-based stats fallback

## Deployment Notes

No configuration changes required. The fix is backward compatible and will work immediately after deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)