### PR TITLE
Fix: Remove LIMIT 10 from IP query in stats API

### DIFF
--- a/api/services/sqlite_parser.py
+++ b/api/services/sqlite_parser.py
@@ -241,7 +241,7 @@ class SQLiteStatsParser:
             )
             totals["unique_download_hashes"] = [row["shasum"] for row in cursor.fetchall()]
 
-            # Top IPs with GeoIP enrichment
+            # All IPs with GeoIP enrichment (no limit for /ips page)
             cursor.execute(
                 """
                 SELECT
@@ -255,7 +255,6 @@ class SQLiteStatsParser:
                 WHERE s.starttime >= ?
                 GROUP BY s.ip
                 ORDER BY count DESC
-                LIMIT 10
                 """,
                 (cutoff_str,),
             )


### PR DESCRIPTION
## Summary
- Fixes /ips page showing only ~10 IPs per source (e.g., 19 for 2 honeypots)
- Removes hardcoded LIMIT 10 from IP address query in API stats endpoint
- Allows /ips page to display all unique attacking IPs as intended

## Changes
- `api/services/sqlite_parser.py`: Removed `LIMIT 10` from IP query (line 258)
- Updated comment to clarify this returns ALL IPs for the /ips page

## Testing
Before: /ips page shows 19 IPs for 48 hours  
After: /ips page shows all unique IPs from sessions table

## Related Issue
Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)