### PR TITLE
Performance: Phase 1 quick wins - caching, limits, loading indicators

### DIFF
--- a/web/templates/downloads.html
+++ b/web/templates/downloads.html
@@ -3,6 +3,21 @@
 {% block title %}Downloads - Cowrie Honeypot{% endblock %}
 
 {% block content %}
+<!-- Loading indicator (hidden once page loads) -->
+<div id="loading-overlay" style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.5); z-index: 9999; justify-content: center; align-items: center;">
+    <div style="background: white; padding: 30px; border-radius: 8px; text-align: center;">
+        <div class="spinner" style="border: 4px solid #f3f3f3; border-top: 4px solid #3498db; border-radius: 50%; width: 40px; height: 40px; animation: spin 1s linear infinite; margin: 0 auto 15px;"></div>
+        <p style="margin: 0; font-size: 16px;">Loading download data...</p>
+        <p style="margin: 5px 0 0; font-size: 12px; color: #666;">This may take a few seconds</p>
+    </div>
+</div>
+<style>
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+</style>
+
 <div class="downloads-page">
     <div class="page-header">
         <h1>Downloaded Files</h1>
@@ -28,6 +43,8 @@
 
     <script>
     function updateFilters() {
+        // Show loading overlay while navigating
+        document.getElementById('loading-overlay').style.display = 'flex';
         const source = document.getElementById('source-filter') ? document.getElementById('source-filter').value : '';
         const hours = document.getElementById('hours-filter').value;
         let url = '?hours=' + hours;
@@ -36,6 +53,11 @@
         }
         window.location.href = url;
     }
+
+    // Show loading indicator on any navigation
+    window.addEventListener('beforeunload', function() {
+        document.getElementById('loading-overlay').style.display = 'flex';
+    });
     </script>
 
     <div class="downloads-info">


### PR DESCRIPTION
## Problem

With 11,222 sessions in 24 hours, many dashboard pages take 30-60+ seconds to load. Users perceive pages as broken after 1 second with no feedback.

**Affected pages:**
- Downloads page: Fetches ALL sessions via pagination, extracts downloads
- Sessions/Activity: Fetches ALL sessions for filtering
- IPs, Countries, Credentials, ASNs, Clients: Each fetches ALL sessions

## Solution: Phase 1 Quick Wins

### 1. Increased Cache TTL (5-10x improvement for cached requests)
- **Before**: Stats cached for 30s, sessions for 15s
- **After**: Stats cached for 5 min (300s), sessions for 3 min (180s)
- **Impact**: Repeated page visits = instant load (0.1-0.5s)

### 2. Added Session Limits to Heavy Pages
- **Downloads**: 5,000 sessions per source (was unlimited)
- **Attack map**: 5,000 sessions per source
- **Sessions/Activity**: 10,000 sessions per source (allows filtering)
- **Countries/Credentials/Clients/ASNs**: 5,000 sessions each
- **/api/sessions**: 1,000 sessions (was fetching all)
- **Impact**: Reduces query time from 60s to 5-15s

### 3. Loading Indicators
- Downloads page shows spinner with "Loading data..." message
- Prevents "broken page" perception
- **Impact**: Users see progress, not blank pages

## Changes

### web/multisource.py
- Added `max_sessions` parameter to `parse_all()` and `get_all_sessions_from_source()`
- Stops pagination when limit reached
- Increased CACHE_TTL_STATS from 30s to 300s
- Increased CACHE_TTL_SESSIONS from 15s to 180s

### web/app.py
- Updated all heavy routes to use `max_sessions` parameter
- Downloads, map, countries, credentials, clients, ASNs: 5,000
- Sessions/activity: 10,000 (allows filtering)
- /api/sessions: 1,000

### web/templates/downloads.html
- Added CSS spinner loading overlay
- Shows/hides on navigation

## Expected Results

- **First load (cache miss)**: 5-15 seconds with visible progress
- **Subsequent loads (cache hit)**: Sub-second (0.1-0.5s)
- **User perception**: Page is working, not broken

## Testing

Before merging, test with your 11k session deployment:
1. Visit downloads page (cold cache) → should see spinner, load in 5-15s
2. Refresh page → should load instantly from cache
3. Wait 6 minutes, refresh → should fetch again

## Future Phases

- **Phase 2** (if still needed): Dedicated API endpoints, background pre-computation, SSE
- **Phase 3** (if still needed): Materialized views, stats tables

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)